### PR TITLE
feat: add skill-health-monitor and token-budget-guard to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.
 - [video-downloader/](./video-downloader/) - Download and prepare videos for offline review.
 - [template-skill/](./template-skill/) - Starter template for building new skills.
+- [skill-health-monitor](https://github.com/aptratcn/skill-health-monitor) - Automated health checks for AI agent skill collections. Audit, score, and maintain 10+ skills with structured 5-dimension scoring (0-100 points).
+- [token-budget-guard](https://github.com/aptratcn/token-budget-guard) - Token budget management for AI agents. Progressive disclosure, conversation compression, budget monitoring. 99% context savings.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
 


### PR DESCRIPTION
## What

Adding two practical agent skills to the **Meta & Utilities** section:

### skill-health-monitor
- Automated health checks for AI agent skill collections
- 5-dimension scoring system (Structure, Content, Activity, Compatibility, Discoverability)
- 0-100 point scale with action-oriented recommendations
- **Use case:** Users with 10+ skills need maintenance, not just installation

### token-budget-guard
- Token budget management for AI agents
- Progressive disclosure, conversation compression, budget monitoring
- Claims 99% context savings through smart token awareness
- **Use case:** Addresses the #1 pain point (cost control) validated by free-claude-code trending

Both are zero-dependency, pure markdown skills — matching the list's practical focus.

## Why These Skills

- **Cost control** is the #1 trending topic (free-claude-code: 4000+ stars/day)
- **Skill maintenance** is an underserved gap — everyone installs, nobody audits
- Both solve real pain points, not AI concept packaging