### PR TITLE
Add ariadne-loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Development & Code Tools
 
+- [ariadne-loop](https://github.com/zhangzeyu99-web/ariadne-loop/tree/main/skills/ariadne-loop) - Write verifiable Loop Engineering specs for Codex tasks, GitHub issues, releases, refactors, and handoffs. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo zhangzeyu99-web/ariadne-loop --path skills/ariadne-loop --name ariadne-loop`
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality). Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo hyhmrright/brooks-lint --path skills/brooks-lint --name brooks-lint`
 - [bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor) - Audit Claude Code to Codex harness migrations for AGENTS.md/CLAUDE.md scope, hooks, MCP config, skills, secrets, and validation notes. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo unitedideas/bringyour-mcp --path skills/bringyour-migration-auditor --name bringyour-migration-auditor`
 - [codebase-migrate/](./codebase-migrate/) - Run large codebase migrations and multi-file refactors in reviewable batches with CI verification.


### PR DESCRIPTION
## Summary
Adds ariadne-loop, a Codex skill for turning rough coding-agent work into verifiable Loop Engineering contracts.

## Fit
- Provides a real SKILL.md at zhangzeyu99-web/ariadne-loop/skills/ariadne-loop
- Uses the existing install-skill-from-github pattern
- Focused on development workflows: GitHub issues, releases, refactors, bugfixes, and agent handoffs