### PR TITLE
Add Formo Analytics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.
 - [developer-growth-analysis/](./developer-growth-analysis/) - Analyze Codex chat history for coding patterns and learning gaps.
+- [Formo Analytics](https://github.com/getformo/cli/tree/main/skills/formo-analytics) - Query project-scoped product and onchain analytics through [Formo](https://formo.so) MCP, CLI, or REST. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo getformo/cli --path skills/formo-analytics --name formo-analytics`
 - [lead-research-assistant/](./lead-research-assistant/) - Research leads and enrich records with firmographic data.
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.


### PR DESCRIPTION
## Summary

Adds [Formo Analytics](https://formo.so) to the Data & Analysis section with its canonical source and Codex installation command.

The skill routes agents between Formo MCP, CLI, and REST for project-scoped analytics, SQL, funnels, retention, revenue, and wallet profiles.

The canonical `SKILL.md` passes the official skill-creator validator.
