### PR TITLE
Add scope-checkpoint skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
+- [scope-checkpoint/](./scope-checkpoint/) - Pause implementation when a task starts expanding beyond the requested PR boundary.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.

--- a/scope-checkpoint/SKILL.md
+++ b/scope-checkpoint/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: scope-checkpoint
+description: Pause and re-scope implementation when a task starts expanding beyond the requested PR boundary. Use when review feedback, failing tests, compatibility work, or adjacent discoveries could pull implementation into extra product surfaces, broad cleanup, architectural hardening, or follow-up slices. Especially useful during Ship runs or long-running implementation sessions.
+---
+
+# Scope Checkpoint
+
+## Overview
+
+Use this skill as a circuit breaker, not a standing implementation philosophy.
+Its job is to keep the current PR honest and bounded when new work appears
+during implementation.
+
+## Checkpoint
+
+When scope starts expanding, stop and write a short checkpoint before changing
+more code:
+
+- Original requested outcome
+- Current PR boundary
+- New issue or surface discovered
+- Classification
+- Decision
+
+Keep the checkpoint brief. Its purpose is to prevent accidental scope expansion,
+not to create another plan.
+
+## Classification
+
+Classify each discovered issue before acting:
+
+1. **Current-PR Blocker**
+   Blocks the requested outcome, breaks touched behavior, creates a regression
+   from this change, or invalidates required verification. Fix it now.
+
+2. **Required Compatibility**
+   Existing tests, callers, fixtures, or workflows are legitimate and must be
+   updated for the new contract to pass honestly. Fix it now, but keep the work
+   tied to the current PR boundary.
+
+3. **Follow-Up**
+   Real issue, but not required for this PR to be correct and verifiable. Record
+   it clearly and do not implement it in this PR.
+
+4. **Speculative**
+   Future-proofing, cleanup, abstraction, broad hardening, or convenience work
+   without evidence that it is needed for this PR. Do not implement it.
+
+## Decision Rules
+
+- Do not let a real but non-blocking issue redefine the task.
+- Do not broaden a PR from one product slice into API, export, UI, reset,
+  acceptance, release, or backfill work unless the user explicitly expands the
+  boundary.
+- Do not use this skill to ignore failed verification. If a failure invalidates
+  the current PR, fix the smallest necessary surface.
+- Do not weaken verification, review, security, merge, or closeout gates. Scope
+  control limits new product/code scope; it does not bypass evidence needed to
+  prove the current PR honestly.
+- If the classification changes the product boundary or the safe PR boundary is
+  unclear, ask the user for the boundary rather than continuing to expand.
+
+## Output Shape
+
+Use this shape when reporting the checkpoint:
+
+```md
+Scope checkpoint:
+- Original outcome:
+- Current PR boundary:
+- New issue:
+- Classification:
+- Decision:
+```
+
+Example:
+
+```md
+Scope checkpoint:
+- Original outcome: ship the core Ledger workflow slice.
+- Current PR boundary: transaction IDs, Receiving, Checking, Withdraw, Settle.
+- New issue: admin Ledger export still needs the new Transaction ID field.
+- Classification: Follow-Up.
+- Decision: record a follow-up; do not add export work to this PR.
+```


### PR DESCRIPTION
## Summary

- Add `scope-checkpoint`, a small implementation circuit-breaker skill.
- Document it in the Development & Code Tools section.
- The skill helps agents pause when review feedback, tests, or adjacent discoveries start pulling a PR beyond its intended boundary.

## Validation

- `git diff --check`
- `quick_validate.py /Users/stanhuang/awesome-codex-skills/scope-checkpoint`
