### PR TITLE
Add Unified AI System

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
-- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first self-hosted AI gateway with a Codex plugin and nine MCP tools for provider-free prompt enhancement, health, readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
+- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Public Preview of a terminal-first, self-hosted AI gateway with a Codex plugin and twelve MCP tools for provider-free prompt enhancement, health, readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
 
 ## Using Skills in Codex
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first self-hosted AI gateway with a Codex plugin and eight-tool MCP server for health, readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
 
 ## Using Skills in Codex
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
-- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first self-hosted AI gateway with a Codex plugin and eight-tool MCP server for health, readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
+- [Unified AI System](https://github.com/happy520ai/unified-ai-system) - Terminal-first self-hosted AI gateway with a Codex plugin and nine MCP tools for provider-free prompt enhancement, health, readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds Unified AI System to Meta and Utilities as an external Codex skill and MCP-backed gateway.

Repository: https://github.com/happy520ai/unified-ai-system

Why it fits:

- Public Apache-2.0 project with an installable `SKILL.md`.
- Codex plugin manifest plus a published stdio MCP server.
- Twelve bounded tools, including local provider-free prompt enhancement, gateway health/readiness, credential-free fake-provider chat, knowledge, workflows, and workforce inspection.
- Terminal-first and self-hosted; the first proof path needs no provider key or account.
- Current maturity is Public Preview, not production GA.

Validation:

- One README line matching the repository's accepted external-entry format.
- Source repository, skill link, plugin manifest, license, and Official MCP Registry entry verified.
- Current source public checks run with real-provider calls disabled.

Current release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.5.0  
Official Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.5.0  
Prompt enhancement evidence: `pnpm gateway enhance "Build a small API for my team" --profile coding --evidence`

The project makes no production-readiness, L5, or AGI claim.
