### PR TITLE
Add Talivia Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
+- [Talivia Agent Kit](https://github.com/talivia-group/agent) - Install and verify revenue-first website analytics from Codex with a bundled skill, CLI, and remote MCP server that connects traffic to payment attribution.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publish approved short-form videos from Codex with a bundled skill, CLI, and remote MCP server for TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.
 
 ### Communication & Writing


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

This adds the reusable Talivia skill, CLI, and remote MCP server to the Codex skills catalog.