### PR TITLE
Stop leaking GITHUB_TOKEN to redirect targets in the skill installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/skill-installer/SKILL.md
+++ b/skill-installer/SKILL.md
@@ -50,7 +50,7 @@ All of these scripts use network, so when running in the sandbox, request escala
 ## Notes
 
 - Curated listing is fetched from `https://github.com/openai/skills/tree/main/skills/.curated` via the GitHub API. If it is unavailable, explain the error and exit.
-- Private GitHub repos can be accessed via existing git credentials or optional `GITHUB_TOKEN`/`GH_TOKEN` for download.
+- Private GitHub repos can be accessed via existing git credentials or optional `GITHUB_TOKEN`/`GH_TOKEN` for download. The token is only ever sent to `https://` GitHub hosts (`github.com`, `githubusercontent.com` and their subdomains) and is dropped if a redirect leads anywhere else.
 - Git fallback tries HTTPS first, then SSH.
 - The skills at https://github.com/openai/skills/tree/main/skills/.system are preinstalled, so no need to help users install those. If they ask, just explain this. If they insist, you can download and overwrite.
 - Installed annotations come from `$CODEX_HOME/skills`.

--- a/skill-installer/scripts/github_utils.py
+++ b/skill-installer/scripts/github_utils.py
@@ -4,18 +4,73 @@
 from __future__ import annotations
 
 import os
+import urllib.parse
 import urllib.request
 
+# Hosts entitled to see the user's GitHub token. Archive downloads legitimately
+# redirect from api.github.com to codeload.github.com and to
+# objects.githubusercontent.com, so both domains (and their subdomains) count.
+TRUSTED_HOST_SUFFIXES = ("github.com", "githubusercontent.com")
 
-def github_request(url: str, user_agent: str) -> bytes:
+DEFAULT_TIMEOUT = 30
+
+
+def is_trusted_url(url: str) -> bool:
+    """True when *url* is an https GitHub URL that may receive credentials."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return any(
+        host == suffix or host.endswith("." + suffix)
+        for suffix in TRUSTED_HOST_SUFFIXES
+    )
+
+
+def _strip_authorization(request: urllib.request.Request) -> None:
+    for header in list(request.headers):
+        if header.lower() == "authorization":
+            del request.headers[header]
+    for header in list(request.unredirected_hdrs):
+        if header.lower() == "authorization":
+            del request.unredirected_hdrs[header]
+
+
+class _AuthScopingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Drop the Authorization header when a redirect leaves trusted GitHub hosts.
+
+    urllib copies every header onto the redirect request, so without this a
+    redirect to an attacker-controlled host would receive the user's token.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_request = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_request is not None and not is_trusted_url(new_request.full_url):
+            _strip_authorization(new_request)
+        return new_request
+
+
+_opener = urllib.request.build_opener(_AuthScopingRedirectHandler)
+
+
+def github_request(url: str, user_agent: str, timeout: int = DEFAULT_TIMEOUT) -> bytes:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError(f"Refusing to request a non-https URL: {url}")
+
     headers = {"User-Agent": user_agent}
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if token:
+    # Only GitHub hosts get the credential; a non-GitHub URL is still fetched,
+    # just anonymously.
+    if token and is_trusted_url(url):
         headers["Authorization"] = f"token {token}"
     req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req) as resp:
+    with _opener.open(req, timeout=timeout) as resp:
         return resp.read()
 
 
 def github_api_contents_url(repo: str, path: str, ref: str) -> str:
+    repo = urllib.parse.quote(repo.strip("/"), safe="/")
+    path = urllib.parse.quote(path.strip("/"), safe="/")
+    ref = urllib.parse.quote(ref, safe="")
     return f"https://api.github.com/repos/{repo}/contents/{path}?ref={ref}"

--- a/skill-installer/scripts/install-skill-from-github.py
+++ b/skill-installer/scripts/install-skill-from-github.py
@@ -80,8 +80,26 @@ def _parse_github_url(
     return owner, repo, ref, subpath or None
 
 
+def _quote_segment(value: str) -> str:
+    """Percent-encode a single URL path segment."""
+    if not value:
+        raise InstallError("Empty URL path segment.")
+    return urllib.parse.quote(value, safe="")
+
+
+def _quote_ref(ref: str) -> str:
+    """Percent-encode a git ref, keeping the slashes in names like feature/x."""
+    parts = ref.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise InstallError(f"Invalid git ref: {ref}")
+    return "/".join(_quote_segment(part) for part in parts)
+
+
 def _download_repo_zip(owner: str, repo: str, ref: str, dest_dir: str) -> str:
-    zip_url = f"https://codeload.github.com/{owner}/{repo}/zip/{ref}"
+    zip_url = (
+        f"https://codeload.github.com/{_quote_segment(owner)}/"
+        f"{_quote_segment(repo)}/zip/{_quote_ref(ref)}"
+    )
     zip_path = os.path.join(dest_dir, "repo.zip")
     try:
         payload = _request(zip_url)
@@ -100,7 +118,9 @@ def _download_repo_zip(owner: str, repo: str, ref: str, dest_dir: str) -> str:
 
 
 def _github_default_branch(owner: str, repo: str) -> str:
-    api_url = f"https://api.github.com/repos/{owner}/{repo}"
+    api_url = (
+        f"https://api.github.com/repos/{_quote_segment(owner)}/{_quote_segment(repo)}"
+    )
     try:
         payload = _request(api_url)
     except urllib.error.HTTPError as exc:

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -1,0 +1,243 @@
+"""Tests for skill-installer credential scoping."""
+
+from __future__ import annotations
+
+import email.message
+import http.server
+import importlib.util
+import os
+import sys
+import threading
+import urllib.request
+
+import pytest
+
+SCRIPTS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "skill-installer",
+    "scripts",
+)
+sys.path.insert(0, SCRIPTS)
+
+import github_utils  # noqa: E402
+
+
+def _load_installer():
+    path = os.path.join(SCRIPTS, "install-skill-from-github.py")
+    spec = importlib.util.spec_from_file_location("install_skill_from_github", path)
+    module = importlib.util.module_from_spec(spec)
+    # @dataclass resolves annotations through sys.modules, so register first.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+installer = _load_installer()
+
+
+@pytest.mark.parametrize(
+    "url, trusted",
+    [
+        ("https://github.com/owner/repo", True),
+        ("https://api.github.com/repos/owner/repo", True),
+        ("https://codeload.github.com/owner/repo/zip/main", True),
+        ("https://objects.githubusercontent.com/blob", True),
+        ("http://github.com/owner/repo", False),  # cleartext
+        ("https://evil.com/owner/repo", False),
+        ("https://github.com.evil.com/owner/repo", False),  # suffix look-alike
+        ("https://notgithub.com/owner/repo", False),
+        ("https://evil.com/?x=github.com", False),
+        ("https://GITHUB.COM/owner/repo", True),  # host casing
+    ],
+)
+def test_is_trusted_url(url, trusted):
+    assert github_utils.is_trusted_url(url) is trusted
+
+
+def _redirect(from_url, to_url):
+    handler = github_utils._AuthScopingRedirectHandler()
+    request = urllib.request.Request(
+        from_url, headers={"Authorization": "token SECRET", "User-Agent": "test"}
+    )
+    new_request = handler.redirect_request(
+        request, None, 302, "Found", email.message.Message(), to_url
+    )
+    assert new_request is not None
+    return new_request
+
+
+def test_redirect_off_github_strips_authorization():
+    new_request = _redirect("https://api.github.com/repos/o/r", "https://evil.com/x")
+
+    assert new_request.get_header("Authorization") is None
+    assert new_request.get_header("User-agent") == "test"
+
+
+def test_redirect_downgrade_to_http_strips_authorization():
+    new_request = _redirect("https://api.github.com/repos/o/r", "http://github.com/x")
+
+    assert new_request.get_header("Authorization") is None
+
+
+def test_redirect_within_github_keeps_authorization():
+    new_request = _redirect(
+        "https://api.github.com/repos/o/r",
+        "https://objects.githubusercontent.com/archive",
+    )
+
+    assert new_request.get_header("Authorization") == "token SECRET"
+
+
+class _CapturingOpener:
+    def __init__(self):
+        self.request = None
+        self.timeout = None
+
+    def open(self, request, timeout=None):  # noqa: A003 - mirrors urllib's API
+        self.request = request
+        self.timeout = timeout
+        return self
+
+    def read(self):
+        return b"payload"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+@pytest.fixture
+def capturing_opener(monkeypatch):
+    opener = _CapturingOpener()
+    monkeypatch.setattr(github_utils, "_opener", opener)
+    monkeypatch.setenv("GITHUB_TOKEN", "SECRET")
+    return opener
+
+
+def test_token_is_sent_to_github(capturing_opener):
+    assert github_utils.github_request("https://api.github.com/repos/o/r", "ua") == b"payload"
+
+    assert capturing_opener.request.get_header("Authorization") == "token SECRET"
+    assert capturing_opener.timeout == github_utils.DEFAULT_TIMEOUT
+
+
+def test_token_is_withheld_from_non_github_hosts(capturing_opener):
+    github_utils.github_request("https://evil.com/repos/o/r", "ua")
+
+    assert capturing_opener.request.get_header("Authorization") is None
+
+
+def test_gh_token_is_used_as_a_fallback(capturing_opener, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN")
+    monkeypatch.setenv("GH_TOKEN", "FALLBACK")
+
+    github_utils.github_request("https://api.github.com/repos/o/r", "ua")
+
+    assert capturing_opener.request.get_header("Authorization") == "token FALLBACK"
+
+
+def test_no_token_sends_no_authorization_header(capturing_opener, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    github_utils.github_request("https://api.github.com/repos/o/r", "ua")
+
+    assert capturing_opener.request.get_header("Authorization") is None
+
+
+@pytest.mark.parametrize("url", ["http://api.github.com/x", "file:///etc/passwd"])
+def test_non_https_urls_are_refused(url, capturing_opener):
+    with pytest.raises(ValueError):
+        github_utils.github_request(url, "ua")
+
+    assert capturing_opener.request is None
+
+
+class _RedirectServer(http.server.BaseHTTPRequestHandler):
+    """Redirects /start to a second server and records headers on arrival."""
+
+    target = ""
+    seen: dict = {}
+
+    def do_GET(self):  # noqa: N802 - http.server API
+        if self.path == "/start":
+            self.send_response(302)
+            self.send_header("Location", self.target)
+            self.end_headers()
+            return
+        type(self).seen["authorization"] = self.headers.get("Authorization")
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def test_authorization_is_not_forwarded_across_a_real_redirect():
+    """End-to-end regression test for the reported token leak."""
+    seen: dict = {}
+
+    class Handler(_RedirectServer):
+        pass
+
+    Handler.seen = seen
+
+    first = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    second = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    Handler.target = f"http://127.0.0.1:{second.server_address[1]}/landing"
+
+    for server in (first, second):
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{first.server_address[1]}/start",
+            headers={"Authorization": "token SECRET", "User-Agent": "test"},
+        )
+        with github_utils._opener.open(request, timeout=10) as response:
+            assert response.read() == b"ok"
+    finally:
+        for server in (first, second):
+            server.shutdown()
+            server.server_close()
+
+    assert seen["authorization"] is None
+
+
+def test_contents_url_encodes_user_input():
+    url = github_utils.github_api_contents_url(
+        "owner/repo", "skills/.curated", "feature branch"
+    )
+
+    assert url == (
+        "https://api.github.com/repos/owner/repo/contents/skills/.curated"
+        "?ref=feature%20branch"
+    )
+
+
+def test_contents_url_cannot_inject_query_parameters():
+    url = github_utils.github_api_contents_url("owner/repo", "a?b=c#d", "main")
+
+    assert url == (
+        "https://api.github.com/repos/owner/repo/contents/a%3Fb%3Dc%23d?ref=main"
+    )
+
+
+def test_quote_ref_keeps_slashes_and_rejects_traversal():
+    assert installer._quote_ref("feature/new thing") == "feature/new%20thing"
+
+    for bad in ("../../x", "a/../b", "a//b", ""):
+        with pytest.raises(installer.InstallError):
+            installer._quote_ref(bad)
+
+
+def test_quote_segment_encodes_separators():
+    assert installer._quote_segment("owner/../evil") == "owner%2F..%2Fevil"
+
+    with pytest.raises(installer.InstallError):
+        installer._quote_segment("")


### PR DESCRIPTION
Closes #224

## The bug

`skill-installer/scripts/github_utils.py` attached the user's token to the request and then let `urlopen` follow redirects. `urllib`'s `HTTPRedirectHandler` copies every header except `Content-Length`/`Content-Type` onto the redirect request, so **`Authorization` travelled to whatever host the server pointed at** — a different domain, or a downgrade to plain `http://`.

Reproduced with two local servers, the first redirecting to the second:

```
Header seen by the *redirect target* host: {'auth': 'token ghp_SECRET_TOKEN', ...}
```

Both entry points are reachable with user-supplied arguments (`--repo`, `--url`, `--ref`, `--path`), and the README plus many catalog entries tell users to run the installer against third-party repositories. A redirect anywhere on that path silently exfiltrates a token that usually carries `repo` scope, while the install still succeeds.

## The fix

Treat authentication as a property of the destination, re-evaluated on every hop:

- `is_trusted_url()` — the token is attached only when the URL is `https` **and** the host is `github.com` or `githubusercontent.com`, or a subdomain. GitHub archive downloads redirect to `codeload.github.com` / `objects.githubusercontent.com`, so private-repo installs keep working; a look-alike such as `github.com.evil.com` does not match.
- `_AuthScopingRedirectHandler` strips `Authorization` (from both `headers` and `unredirected_hdrs`) whenever a redirect target fails that check. Requests now go through an opener built with it rather than the module-level `urlopen`.
- Non-`https` URLs are refused outright instead of sending credentials in cleartext, and a 30s timeout replaces the previous unbounded wait.
- Owner, repo, ref and path are percent-encoded when building GitHub URLs, and refs with empty/`.`/`..` segments are rejected. Slashes are preserved in ref names, so `--ref refs/heads/master` still works.

A non-GitHub URL is still fetched — just anonymously — so nothing that worked without a token breaks.

## Tests

`tests/test_github_utils.py`, 24 cases: the host/scheme matrix (including the `github.com.evil.com` look-alike and host casing), redirect stripping in both directions, which header is sent for `GITHUB_TOKEN` / `GH_TOKEN` / neither / untrusted host, non-https refusal, URL encoding, and ref validation — plus an **end-to-end redirect chain over real sockets** asserting the second host receives no `Authorization`. That last test fails against the previous implementation:

```
$ python -m pytest tests/test_github_utils.py -q
24 passed in 1.13s

# same test, with the pre-fix opener restored:
E       AssertionError: assert 'token SECRET' is None
```

Manually verified against the real repo with no token set: `--repo/--path` install, `--url` tree-URL install, `--ref refs/heads/master`, and `list-curated-skills.py` all still succeed.

## Note on overlap

This branch adds `tests/` and `.gitignore`, which #223 also adds (identical `.gitignore`, different test file). Whichever merges first, the other should merge cleanly; #223 is what wires `tests/` into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
