### PR TITLE
Add RepoStudio skill (repo to narrated explainer video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [RepoStudio](https://github.com/wushidiguo/RepoStudio) - Turn any GitHub repository into a 1-3 minute narrated explainer video: clone → deep codebase analysis → Playwright screenshots → Mermaid/Graphviz diagrams → timed narration script → TTS voiceover (edge-tts / Qwen3-TTS) → Remotion MP4 render. Bilingual narration and .srt subtitles. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo wushidiguo/RepoStudio --path skills/repo-to-video --name repo-to-video`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
RepoStudio is a Codex skill that turns any GitHub repository into a 1-3 minute narrated explainer video. Pipeline: clone -> deep codebase analysis -> Playwright screenshots -> Mermaid/Graphviz diagrams -> timed narration script (manifest.json) -> TTS voiceover (edge-tts / Qwen3-TTS) -> Remotion render. Written in Python + TypeScript, MIT licensed, with bilingual narration and .srt subtitle export.