### PR TITLE
Add SpineCodex to contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The installer fetches the skill and places it in `$CODEX_HOME/skills/<skill-name
 ## Contents
 
 - [Bernstein](https://github.com/chernistry/bernstein) - Multi-agent orchestrator with Codex CLI adapter. Runs parallel Codex agents in isolated git worktrees with quality gates.
+- [SpineCodex](https://github.com/GhabiX/SpineCodex) - Enhanced Codex CLI for long-running tasks: 10× effective context via SpineJIT context-tree compilation, recursive subagent scaling on demand, and 89% more tasks resolved at 27% lower cost on SWE-Milestone.
 - [What Are Codex Skills?](#what-are-codex-skills)
 - [Skills](#skills)
   - [Development & Code Tools](#development--code-tools)


### PR DESCRIPTION
Adds [SpineCodex](https://github.com/GhabiX/SpineCodex) to the Contents list.

SpineCodex is an enhanced, independently maintained Codex CLI distribution for complex long-running software engineering tasks:
- **10× effective context** via SpineJIT context-tree compilation (256K → 2.5M effective working context)
- **Recursive subagent scaling** on demand (divide-and-conquer for long tasks)
- **89% more tasks resolved at 27% lower cost** on SWE-Milestone, +10.8pp on ProgramBench, +9.2pp on FrontierSWE
- npm: `@spinejit/spine-codex`, inherits existing Codex config out of the box

It fits alongside the existing Bernstein entry as a Codex CLI enhancement/distribution.