### PR TITLE
Add codex-yi: multi-thread Codex memory system skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publish approved short-form videos from Codex with a bundled skill, CLI, and remote MCP server for TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.
 
+- [codex-yi](https://github.com/alex12138356/codex-yi-skill) - Multi-thread Codex memory system: shared knowledge base, hub dispatcher, report-back log and SESSION_LOG resume to survive the 400 cutoff.
+
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.
 


### PR DESCRIPTION
Adds [codex-yi](https://github.com/alex12138356/codex-yi-skill) to the Productivity & Collaboration section.

A 7-file skill (shared knowledge base, kickoff instructions, hub dispatcher guide, SESSION_LOG, report-back log, project tracker, collaboration protocol) that gives Codex persistent memory across conversations and survives the 400-message cutoff. Free generator at codex-yi.com; bilingual SKILL.md (zh/en).