### PR TITLE
Add DeepRead evidence-first reading skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Data & Analysis
 
+- [DeepRead](https://github.com/xiehuan123/dsh-deepread) - Evidence-first deep reading for articles, books, PDFs, and document sets. Traces claims to evidence and source locations, marks uncertainty, and produces knowledge maps or Feynman review plans. Install: `npx skills@latest add xiehuan123/dsh-deepread`
 - [spreadsheet-formula-helper/](./spreadsheet-formula-helper/) - Write and debug spreadsheet formulas, pivots, and array formulas.
 - [competitive-ads-extractor/](./competitive-ads-extractor/) - Analyze competitor ads and extract structured insights.
 - [datadog-logs/](./datadog-logs/) - Filter Datadog logs from the shell via the Composio CLI, with JSON-friendly output and digest workflows.


### PR DESCRIPTION
## Summary

Adds DeepRead as an external Codex-compatible skill under Data & Analysis.

DeepRead handles a practical gap between generic summarization and source-grounded analysis: it requires important claims to be paired with evidence and source locations, marks unsupported statements explicitly, and can produce knowledge maps, cross-document comparisons, or Feynman review plans.

## Codex usage

```sh
npx skills@latest add xiehuan123/dsh-deepread
```

```text
Deep-read architecture.pdf in knowledge-map mode. Trace each important claim
to its evidence and page location, and mark anything the source does not support.
```

The skill has an English trigger description, no runtime dependencies, prompt-injection guidance for source documents, and real output examples in the project README. The same repository also provides an optional full DeepSeek Harness plugin, clearly documented as a separate runtime form.
