### PR TITLE
Add Aeon to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs 70+ `SKILL.md` skills entirely inside GitHub Actions on a cron schedule. Self-healing (a health skill files issues, a repair skill fixes them by PR) and fleet-replicating, it runs each skill through the Codex CLI as one of six supported coding-agent harnesses.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Skills → Development & Code Tools**, alongside the other multi-skill frameworks (AuraKit, Vibe-Skills, polywave).

Aeon is an autonomous agent framework that runs 70+ `SKILL.md` skills entirely inside GitHub Actions on a cron schedule. It's self-healing (a health skill files issues, a repair skill fixes them by PR) and fleet-replicating.

**Why it fits this list:** Aeon runs each skill through a unified Claude-Code-shaped contract across six coding-agent harnesses, and the **Codex CLI is one of them** — the same `SKILL.md` skills execute on Codex. So it's a Codex-compatible skills collection.

- Repo: https://github.com/aeonfun/aeon
- License: MIT · actively maintained (daily commits)

Placed as a single entry at the end of Development & Code Tools, formatting matched to the surrounding external-repo lines.

Disclosure: I maintain Aeon.