### PR TITLE
Add UIZZE anti-ui-slop Codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
+- [UIZZE anti-ui-slop Skill](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Free MIT Codex Skill for design contracts, required UI states, anti-slop review, and a hard finish gate; optional [UIZZE](https://uizze.com/) workflow researches 800,000+ real web and iOS screens.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.


### PR DESCRIPTION
Adds UIZZE to the Development & Code Tools section as a portable Codex skill.\n\n- Free MIT anti-ui-slop Skill, installed from the canonical repository\n- Covers design contracts, required UI states, anti-slop review, and a hard finish gate\n- Separates the optional UIZZE workflow and its 800,000+ real web and iOS screen scope\n\nThis follows the repository's existing link-first skill entries and keeps the diff to one line.