### PR TITLE
Add PostAngle to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [novel-writing](https://github.com/wgwtest/novel-writing) - External repo: public Codex skill for fiction planning, chapter drafting, scene continuation, and revision.
 - [tailored-resume-generator/](./tailored-resume-generator/) - Tailor resumes to job descriptions with quantified impact.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - External repo: CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, and sycophancy openers. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode.
+- [PostAngle](https://github.com/luohechentim/postangle) - Find a defensible content angle, gate claims on evidence, adapt Chinese and English for each audience, and publish to X only after human confirmation.
 
 ### Data & Analysis
 


### PR DESCRIPTION
## Summary

Adds PostAngle as an external Codex skill reference under Communication & Writing.

PostAngle helps Codex choose a defensible content angle, gate claims on evidence, adapt Chinese and English for each audience, and require human confirmation before publishing to X.

Repository: https://github.com/luohechentim/postangle

## Validation

- `git diff --check`
- Confirmed the public repository link resolves
- Confirmed there is no existing PostAngle PR
- Follows recent merged external-skill contribution patterns