### PR TITLE
Add x-research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [x-research](https://github.com/agentbody/skills/tree/main/skills/x-research) - Read-only X/Twitter research: public post search, trends, post details, profiles, profile posts/media, and replies via a bundled Python client.
 
 ### Meta & Utilities
 


### PR DESCRIPTION
Adds AgentBody's X Research skill to the Data & Analysis section.

**Skill:** [x-research](https://github.com/agentbody/skills/tree/main/skills/x-research)
**Description:** Read-only X/Twitter research: public post search, trends, post details, profiles, profile posts/media, and replies via a bundled Python client.
**License:** MIT