### PR TITLE
Add repo-cover to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [template-skill/](./template-skill/) - Starter template for building new skills.
 - [skill-installer/](./skill-installer/) - Helper scripts to install skills from curated lists or GitHub paths.
 - [skill-creator/](./skill-creator/) - Guidance for building effective Codex skills with progressive disclosure.
+- [repo-cover](https://github.com/sjh9714/repo-cover) - External repo: design GitHub social-preview cards (og:image, 1280x640) as one self-contained HTML file with four editorial moods, CJK-first typography, and deterministic design checks.
 
 ## Using Skills in Codex
 


### PR DESCRIPTION
Adds [repo-cover](https://github.com/sjh9714/repo-cover) as an external-repo entry, next to the other visual utilities (canvas-design, theme-factory, image-enhancer).

repo-cover has the agent design a repository's GitHub social-preview card (og:image, 1280x640) as one self-contained HTML file. The skill's description states the trigger clearly (social preview, repo cover, og image, link card, README hero), SKILL.md stays under 100 lines with references loaded per mood, and a stdlib Python checker validates canvas, self-containment, WCAG contrast, and CJK line-breaking. Tested in Codex-compatible agents through the skills CLI (npx skills add sjh9714/repo-cover). A live gallery with view-source examples is at https://sjh9714.github.io/repo-cover/