### PR TITLE
Add Multi-Source Search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [domain-name-brainstormer/](./domain-name-brainstormer/) - Brainstorm available domain names with criteria and checks.
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
+- [multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search) - Cross-check a claim across web, academic, and host-provided search tools, then produce a claim-to-source evidence ledger with disagreements, gaps, and confidence levels. Includes an offline report validator and does not require a SandBase account. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo sandbaseai/sandbase-skills --path research/multi-source-search --name multi-source-search`
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
 
 ### Meta & Utilities


### PR DESCRIPTION
## Summary

Add the external `multi-source-search` Codex Skill to Data & Analysis.

## Why it is useful

The Skill provides a reusable workflow for checking a claim across multiple retrieval systems instead of trusting one ranked result. Its output contract requires a claim-to-source evidence ledger, explicit disagreements and evidence gaps, and per-finding confidence. It also ships an offline validator for the final report.

The default workflow works with search capabilities already available to the host agent and does not require a SandBase account or paid API. Optional providers can expand coverage.

## Validation

- installed the nested Skill successfully with Codex's bundled `install-skill-from-github.py`
- verified the installed `SKILL.md` and validator script are present
- verified the canonical GitHub link and Apache-2.0 repository license
- ran `git diff --check`

Disclosure: I am contributing on behalf of the SandBase project.
