### PR TITLE
Add persona-auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [persona-auditor](https://github.com/kevinshi3200/persona-auditor) - Audit AI-generated code from a real user's perspective: digital personas exhaustively traverse every user journey, then god's-eye attribution collapses bugs into a few root causes for precise fixing. Install: `npx skills add kevinshi3200/persona-auditor -a codex`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## persona-auditor

Audit AI-generated code from a real user's perspective — surfacing the errors you'd only discover through costly trial-and-error, or never notice at all.

**What it does:**
- Dispatches "digital personas" (subagents) that each play a real user type, exhaustively traversing every user journey on paper (no execution needed)
- God's-eye counterfactual attribution collapses dozens of symptoms into a few root causes, each with a `file:line` and a falsifiable verification method
- Six-layer coverage: logic/state, user experience, security (34 classes), AI-smell, compliance/release, concurrency, cross-project
- Two exclusive checks: release hygiene (AI-specific leaks) + wheel-reinvention audit

**Repo:** https://github.com/kevinshi3200/persona-auditor
**Install:** `npx skills add kevinshi3200/persona-auditor -a codex`