### PR TITLE
Add famulor-skill to Productivity & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 - [connect/](./connect/) - Connect Codex to 1000+ apps via the Composio CLI for real actions (Slack, GitHub, Notion, etc.).
 - [connect-apps/](./connect-apps/) - Wire up Composio CLI connections for Claude and kick off app workflows from the shell.
+- [famulor-skill](https://github.com/bekservice/Famulor-Skill/tree/main/skills/famulor-skill) - Operate Famulor assistants, omnichannel history, calls, campaigns, messaging, knowledge, and automations through its hosted MCP server. Trigger: when a request needs actual Famulor workspace data or actions. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo bekservice/Famulor-Skill --path skills/famulor-skill --name famulor-skill`
 - [issue-triage/](./issue-triage/) - Triage Linear or Jira backlogs and run bug sweeps from the terminal.
 - [linear/](./linear/) - Manage issues, projects, and team workflows in Linear.
 - [meeting-insights-analyzer/](./meeting-insights-analyzer/) - Analyze meeting transcripts for themes, risks, and follow-ups.


### PR DESCRIPTION
## Summary

Adds `famulor-skill` under **Productivity & Collaboration** as an external Codex skill for operating a Famulor workspace through its hosted MCP server.

The entry includes:

- the canonical skill path;
- a precise trigger: requests that need actual Famulor workspace data or actions; and
- a reproducible Codex Skill Installer command.

## Install

```bash
python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo bekservice/Famulor-Skill --path skills/famulor-skill --name famulor-skill
```

The skill is MIT-licensed. The separate linked MCP service is hosted and authenticates through browser OAuth; this PR makes no open-source license claim about its server implementation.

## Validation

- Confirmed no existing Famulor entry, issue, or PR in this repository.
- `npx -y skills add bekservice/Famulor-Skill --list` discovered exactly one skill: `famulor-skill`.
- The repository's Skill Installer completed against the documented path in an isolated destination, and `diff -rq` matched the canonical source directory.
- The source skill link returned HTTP 200.
- The hosted MCP endpoint returned its expected OAuth challenge.
- `git diff --check` passed.

Disclosure: first-party submission by the skill repository owner, prepared with AI assistance and reviewed before submission.