### PR TITLE
Add WeChat Bridge Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Communication & Writing
 - [codex-sms-verification](https://github.com/virtualsms-io/codex-sms-verification) - External repo: real-SIM SMS verification for AI agents via VirtualSMS MCP. 145+ countries, 2000+ services, both hosted (mcp.virtualsms.io) and local stdio transports.
+- [WeChat Bridge](https://github.com/Sutera-Diffusus/WeChat-daily/tree/main/plugins/wechat-bridge) - External Codex plugin for a local WeChat service: inspect status and recent messages, preview analysis and replies, and keep text sending behind explicit confirmation.
 
 - [email-draft-polish/](./email-draft-polish/) - Draft, rewrite, or condense emails for the right tone and audience.
 - [changelog-generator/](./changelog-generator/) - Create clear changelogs from commits or summaries.


### PR DESCRIPTION
Adds an external WeChat Bridge plugin under Communication & Writing.

The plugin lives in the Weiyu repository and exposes a small local interface for checking service status, reading recent messages, previewing analysis and replies, and retrying or sending text only through the existing confirmation and safety gates. It talks to the same loopback service as the desktop app and does not add a cloud relay.

The link points to the plugin directory so the source, plugin manifest, MCP server, and skill instructions can be reviewed together. If the list only accepts standalone skill folders, I can prepare a separate package.