### PR TITLE
Add skill: kotobuki09/instructree

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS: CF Workers + Hono + Angular + D1 + Stripe. One-line prompts to deployed SaaS with 94 reference docs, 18 agents, and Codex-native `.agents/skills/` support.
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
+- [instructree](https://github.com/kotobuki09/instructree/tree/main/skills/instructree) - Map and lint coding-agent instruction scope, imports, metadata, links, and possible conflicts. Install: `npx skills add kotobuki09/instructree --skill instructree -g --agent codex`
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.


### PR DESCRIPTION
## Summary

Adds Instructree to Development & Code Tools. The linked skill helps Codex map and lint AGENTS.md, CLAUDE.md, Copilot instructions, agent skills, recursive imports, metadata, links, and possible instruction conflicts.

## Verification

- public MIT repository with v0.4.0 release
- native SKILL.md with valid name and description frontmatter
- install command verified with the Skills CLI
- CLI and GitHub Action tested across Windows, macOS, and Linux