### PR TITLE
Add falsify — scientific thinking protocol skill (Meta & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [falsify](https://github.com/263311487-ux/falsify) - 5-stage scientific thinking protocol (Axiomatize → Hypothesize → Adversarialize → Verify → Converge). Stops Codex from giving confident answers it cannot falsify; ships 28 eval cases + external dogfood validation (4/4 real-community questions passed, 3/3 ground-truth matched). Install: `npx skills add 263311487-ux/falsify` (Codex-native `.codex-plugin/` included).
 
 ### Productivity & Collaboration
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.
+- [falsify](https://github.com/263311487-ux/falsify) - The scientific thinking protocol for Codex: falsification-first (axioms → hypothesis → adversarial test → evidence → calibrated verdict). No verdict without a falsifiable hypothesis — stops confident unverifiable answers. Ships a live browser checker, 30+ bias catalog, mental-model toolbox, and a 28-case runnable eval suite (dual-model 26/28). Install: `npx skills add 263311487-ux/falsify`
 - [image-enhancer/](./image-enhancer/) - Upscale and refine images with configurable presets.
 - [slack-gif-creator/](./slack-gif-creator/) - Generate GIFs for Slack with captions and styling.
 - [theme-factory/](./theme-factory/) - Create reusable theme tokens and palettes.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
-- [falsify](https://github.com/263311487-ux/falsify) - 5-stage scientific thinking protocol (Axiomatize → Hypothesize → Adversarialize → Verify → Converge). Stops Codex from giving confident answers it cannot falsify; ships 28 eval cases + external dogfood validation (4/4 real-community questions passed, 3/3 ground-truth matched). Install: `npx skills add 263311487-ux/falsify` (Codex-native `.codex-plugin/` included).
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## What

Add [falsify](https://github.com/263311487-ux/falsify) to **Meta & Utilities**: the scientific thinking protocol for Codex — a 5-stage falsification-first process (Axioms → Hypothesis → Adversarial test → Evidence → Calibrated verdict). *No verdict without a falsifiable hypothesis.*

## Why it belongs

- **Codex-native**: installs via `npx skills add 263311487-ux/falsify` or `npx falsify-skill`; ships `.codex-plugin/` + `SKILL.md` frontmatter with trigger phrases
- **Provable, not vibes**: 28-case runnable eval suite, cross-model validated on two external DeepSeek models both directions (**26/28, avg 15.3–16.4/18**); real-community dogfood 4/4 on GitHub/Stack Overflow questions
- **Live browser checker** (https://263311487-ux.github.io/falsify/) — 8 one-click examples + a 5-question falsifiability quiz, shareable via `?q=`, no install
- **Deep references**: 30+ cognitive-bias catalog + mental-model toolbox (pre-mortem, base rate, Chesterton's Fence, triangulation, Bayes…) load on demand
- **Local & private**: pure Markdown + local JS, zero network calls

Distilled from 70+ sources — ICML 2026 Bayes-consistency, MetaCrit, CIA ACH (Heuer), Lakatos, Mayo, Toulmin, Pearl do-calculus, Kahneman, Galef, Cynefin, OODA — each mapped to a protocol stage.
