### PR TITLE
Add repo-context-ledger skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [repo-context-ledger](https://github.com/gviiisen/repo-context-ledger/tree/main/skills/repo-context-ledger) - Preserve verified repository context across Codex, Cursor, Claude, and other coding agents with scoped Context Packs and cross-session handoffs. Install: `npx skills@latest add gviiisen/repo-context-ledger --skill repo-context-ledger`
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds repo-context-ledger to Development & Code Tools.

It is a public MIT-licensed Agent Skill for carrying verified repository context across Codex, Cursor, Claude, and other coding agents. The linked skill includes its SKILL.md, runtime scripts, documentation, tests, and a standard skills CLI install command.

I also checked that the linked skill is discoverable with the skills CLI before submitting.