### PR TITLE
Add SandBase Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
+- [SandBase Skills](https://github.com/sandbaseai/sandbase-skills) - 88 portable Agent Skills for research, social intelligence, marketing, and business workflows, including an evidence-ledger-based multi-source search skill with offline validation. Install with `npx skills add sandbaseai/sandbase-skills@multi-source-search --agent codex`.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
 
 ### Productivity & Collaboration


### PR DESCRIPTION
Adds SandBase Skills as an external, portable Codex skills collection. The entry describes the evidence-ledger search workflow and provides the exact Codex install command. Claims were checked against the canonical repository README; no fabricated metrics or star counts are included.