### PR TITLE
Add skill: arbazkhan971/godmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [godmode](https://github.com/arbazkhan971/godmode) - Discipline layer for coding agents: 135 skills and 7 subagents that wrap Codex (and Claude Code, Cursor, Gemini CLI, OpenCode, Amp, and pi) in a measure → modify → verify → keep/revert loop, reverting any change that fails mechanical verification. MIT.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
Adds `godmode` to the **Development & Code Tools** section.

godmode is a discipline-layer skill plugin for coding agents that ships 135 skills and 7 subagents. Its core loop is measure → modify → verify → keep/revert, so every change is backed by evidence and failed experiments are reverted. It works across Codex (native adapter at `adapters/codex/install.sh`), Claude Code, Cursor, Gemini CLI, OpenCode, Amp, and pi.

- Repo: https://github.com/arbazkhan971/godmode
- Release: https://github.com/arbazkhan971/godmode/releases/tag/v2.0.0
- License: MIT

I am the author. Entry follows the existing section format - happy to adjust placement or wording.
