### PR TITLE
Add AI Open Source Intelligence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [ai-open-source-intelligence](https://github.com/zxhwolfe-dev/aiworkstation-open-source-intelligence/tree/main/skills/ai-open-source-intelligence) - Find, verify, compare, and select open-source AI projects with live Radar evidence, direct License checks, honest no-match handling, alternatives, and candidate stack planning. The complete v0.3.3 pre-release Plugin bundles the Skill with nine read-only Hosted MCP tools. Setup: [version-pinned Codex Plugin quickstart](https://github.com/zxhwolfe-dev/aiworkstation-open-source-intelligence/blob/v0.3.3/docs/QUICKSTART.md#complete-plugin-in-codex--chatgpt-desktop).
 
 ### Meta & Utilities
 


### PR DESCRIPTION
## Summary

- adds AI Open Source Intelligence to Data & Analysis
- links the canonical Skill and the version-pinned Codex Plugin quickstart
- describes the evidence, License-check, honest no-match, alternatives, and stack-planning scope
- states that v0.3.3 is a pre-release and that the complete Plugin bundles nine read-only Hosted MCP tools

This is a self-submission from the project maintainer.

## Validation

- the current skills CLI discovers exactly one Skill from the repository
- an isolated Codex install copied SKILL.md, agents/openai.yaml, and references/constraint-schema.md
- the production Hosted MCP smoke test discovered exactly nine tools with read-only, non-destructive annotations and completed a real search call
- both README links return HTTP 200