### PR TITLE
Add skill: anguobao123/semantic-file-organizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [notion-spec-to-implementation/](./notion-spec-to-implementation/) - Turn Notion specs into implementation plans, tasks, and progress tracking.
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
+- [semantic-file-organizer](https://github.com/anguobao123/semantic-file-organizer) - Design human-centered folder taxonomies and apply reviewable no-overwrite migration manifests while protecting related repositories, Git worktrees, path-dependent projects, and symbolic links.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publish approved short-form videos from Codex with a bundled skill, CLI, and remote MCP server for TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.


### PR DESCRIPTION
## Summary

Adds [semantic-file-organizer](https://github.com/anguobao123/semantic-file-organizer) to Productivity & Collaboration.

This is a self-nomination; I maintain the project. It complements the existing `file-organizer` skill by focusing on human retrieval context and parent-folder inheritance, logical code projects across repositories and Git worktrees, path-dependency audits, explicit no-overwrite move manifests with rollback journals, and separately authorized symbolic-link cleanup.

The standalone skill has a root `SKILL.md`, progressive references, a standard-library-only local CLI, and English and Simplified Chinese documentation. Only `README.md` is changed here.

Validation: documentation-only catalog change; no test commands were run.