### PR TITLE
Add skill: codex-project-hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Meta & Utilities
 
+- [Codex Project Hygiene](https://github.com/kotyasmol/codex-project-hygiene) - Prevent Codex project clutter before development by installing reviewable, persistent `AGENTS.md` rules; keeps scratch and rejected media candidates outside repositories, with cleanup explicit and secondary.
+
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.


### PR DESCRIPTION
## Summary

Adds [Codex Project Hygiene](https://github.com/kotyasmol/codex-project-hygiene) to **Meta & Utilities**.

The skill installs one reviewable, persistent policy block in a project's root `AGENTS.md` before development. Future Codex tasks are instructed to reuse useful directories, keep task scratch and rejected media candidates outside the repository, and use semantic artifact names. Cleanup exists only as a separate explicit mode.

## Why it belongs

- real, reusable Codex workflow with precise bootstrap and existing-project audit triggers;
- root `SKILL.md` plus deterministic standard-library Python helpers and progressive references;
- preserves existing project instructions and refuses broad roots, symlinks, malformed markers, and stale approval fingerprints;
- no daemon, telemetry, third-party runtime dependency, or runtime network request.

## Verification

- public macOS and Ubuntu CI across Python 3.9, 3.11, 3.13, and 3.14;
- 126 synthetic tests;
- official Codex skill validator passes;
- checksummed `v0.4.0-beta` release archive.

This PR adds an external catalog link instead of copying the implementation, keeping the MIT-licensed source and security fixes in one canonical repository.
