### PR TITLE
Add Agent Coordinator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
+- [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) - Resume complex Codex jobs from private local state, reconcile uncertain launches before retry, and rerun authored checks before closeout; specialist delegation is optional.
 
 ### Productivity & Collaboration
 


### PR DESCRIPTION
## Summary

Adds Agent Coordinator as an external skill under **Development & Code Tools**.

Agent Coordinator is a per-user Codex skill for complex work that may span interruptions. It preserves private local workflow state, marks uncertain launches for reconciliation before retry, and reruns authored checks at closeout. Specialist delegation is optional; the same lifecycle can run inline.

## Why this section

The section already includes workflow and coordination skills such as Vibe-Skills and polywave. Agent Coordinator shapes how Codex plans, resumes, and checks development work, so this is a closer fit than Meta & Utilities.

## Validation

- The project and its `skill/SKILL.md` are public and MIT-licensed.
- The current main commit has a passing CI run.
- No existing README entry or matching open pull request was found.
- `git diff --check` passes.

Only `README.md` is changed.

## Disclosure

I maintain Agent Coordinator. I prepared this submission with Codex and reviewed the final wording against the public source.
