### PR TITLE
Add backlink directory quality skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [raffle-winner-picker/](./raffle-winner-picker/) - Randomly select winners with audit-friendly logs.
 - [langsmith-fetch/](./langsmith-fetch/) - Pull LangSmith project/test data for analysis.
 - [helium-mcp/](./helium-mcp/) - Search real-time news with bias scoring, get live market data, ML options pricing, and balanced news synthesis via MCP.
+- [submit-product-directories-v2-quality](https://github.com/flaqai/backlink_skills/tree/main/submit-product-directories-v2-quality) - Quality-first product-directory workflow: qualify relevance, audience value, governance, authorization, and listing durability before an auditable, verification-first submission. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo flaqai/backlink_skills --path submit-product-directories-v2-quality --name submit-product-directories-v2-quality`
 
 ### Meta & Utilities
 


### PR DESCRIPTION
## Summary

Adds the external `submit-product-directories-v2-quality` Codex skill from [`flaqai/backlink_skills`](https://github.com/flaqai/backlink_skills/tree/main/submit-product-directories-v2-quality) to **Data & Analysis**.

The skill qualifies product-directory opportunities using relevance, audience value, governance, authorization, and listing durability checks, then prepares auditable, verification-first submissions. Its scope explicitly excludes bulk backlink creation, ranking manipulation, paid link acquisition, and low-quality directory automation.

## Installation

```bash
python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo flaqai/backlink_skills --path submit-product-directories-v2-quality --name submit-product-directories-v2-quality
```

## Verification

- Confirmed the canonical repository and skill path are public and resolve successfully.
- Confirmed the skill has a valid `SKILL.md` frontmatter name/description and is MIT-licensed.
- Ran the repository quick validator in an isolated Python environment: `Skill is valid!`.
- Ran the documented installer into an isolated directory and verified the installed tree matches the source tree.
- Ran `git diff --check`.

Disclosure: I maintain the submitted skill repository; this is a first-party submission prepared with AI assistance and reviewed before opening.
