### PR TITLE
docs: add xhs-research-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [support-ticket-triage/](./support-ticket-triage/) - Triage customer support tickets with categories, priority, next actions, and draft replies.
 - [file-organizer/](./file-organizer/) - Organize, rename, and tidy files to keep workspaces clean.
 - [paperjsx/](./paperjsx/) - Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls.
+- [xhs-research-agent](https://github.com/chang-zy/xhs-research-agent) - Research and operate Xiaohongshu from Codex through an authenticated Chrome session, with verifiable full-comment and profile collection, image/video analysis preparation, publishing, and user-approved interactions.
 - [skill-share/](./skill-share/) - Share skills and reusable instructions across teammates.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publish approved short-form videos from Codex with a bundled skill, CLI, and remote MCP server for TikTok, Instagram Reels, YouTube Shorts, X, and Facebook.
 


### PR DESCRIPTION
Adds [xhs-research-agent](https://github.com/chang-zy/xhs-research-agent) to the Productivity & Collaboration section.

The project provides Codex workflows for Xiaohongshu research and operations, including verifiable comment/profile collection, image and video analysis preparation, publishing, and user-approved interactions.