### PR TITLE
Add agent-kill-switch to Meta & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Meta & Utilities
 
+- [agent-kill-switch](https://github.com/vivekchand/clawmetry/tree/main/skills/agent-kill-switch) — Give the human an off switch and a cost meter for Codex CLI and the other coding agents on the machine, via ClawMetry: see sessions and spend from the logs already on disk, stop a runaway session, hold risky tool calls for approval. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo vivekchand/clawmetry --path skills/agent-kill-switch --name agent-kill-switch`
+
 - [brand-guidelines/](./brand-guidelines/) - Apply OpenAI/Codex brand colors and typography to artifacts.
 - [agent-deep-links/](./agent-deep-links/) - Build and validate deep links for Codex, Cursor, and VS Code with Slack-safe formatting and fallback guidance.
 - [canvas-design/](./canvas-design/) - Generate structured canvas layouts and design artifacts.


### PR DESCRIPTION
Adds agent-kill-switch (external repo, Agent Skills format) under Meta & Utilities, in the same shape as the other external entries with the install-skill-from-github.py line.

What the skill does: teaches Codex to install ClawMetry (https://github.com/vivekchand/clawmetry, https://clawmetry.com), a local dashboard that reads the session logs Codex CLI and the other coding agents already write on disk, then report what is running and what it costs, stop one runaway session on request, and hold high-risk tool calls for approval. Every control is opt-in and the SKILL.md states what each can and cannot do; its description names the trigger phrases so Codex fires it only when asked about cost, a runaway agent, or a kill switch.

Disclosure: I maintain ClawMetry. The skill says plainly that OpenClaw and NemoClaw are free in the open-source app and that Codex CLI and other runtimes need the Cloud or self-hosted Pro tier.