### PR TITLE
Add WorkBuddy Skill Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
+- [WorkBuddy Skill Atlas](https://github.com/sandbaseai/workbuddy-skill) - Search 10,500 provenance-pinned public skills and install reviewed spreadsheet, debugging, or API workflows. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo sandbaseai/workbuddy-skill --path skills/systematic-debugging --name systematic-debugging`
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
 
 ### Productivity & Collaboration


### PR DESCRIPTION
## What this adds

A single Development & Code Tools entry for the WorkBuddy Skill Atlas and its directly installable `systematic-debugging` Skill.

## Why it fits

- standard `SKILL.md` layout compatible with the documented Codex skill installer
- immutable GitHub provenance for 10,500 indexed public Skills
- reviewed adaptations include licenses, source manifests, safety guardrails, and tests
- the linked install command targets one reusable Skill rather than requiring the full catalog

Verified that the repository, Skill path, and installer arguments resolve.