### PR TITLE
Add Arsenal portable workflow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 
 ### Development & Code Tools
 
+- [Arsenal](https://github.com/mirkobozzetto/arsenal) - Portable workflow router and eight focused skills for Codex, Pi, OMP, and Claude Code. Clarifies intent, selects the smallest appropriate workflow, and supports controlled implementation with execution evidence. Install: `codex plugin marketplace add https://github.com/mirkobozzetto/arsenal && codex plugin add arsenal@arsenal`
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality). Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo hyhmrright/brooks-lint --path skills/brooks-lint --name brooks-lint`
 - [bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor) - Audit Claude Code to Codex harness migrations for AGENTS.md/CLAUDE.md scope, hooks, MCP config, skills, secrets, and validation notes. Install: `python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo unitedideas/bringyour-mcp --path skills/bringyour-migration-auditor --name bringyour-migration-auditor`
 - [codebase-migrate/](./codebase-migrate/) - Run large codebase migrations and multi-file refactors in reviewable batches with CI verification.


### PR DESCRIPTION
## Summary

Adds Arsenal to the Development & Code Tools list. Arsenal provides a portable workflow router and eight focused skills for Codex, Pi, OMP, and Claude Code, with optional controlled execution and verification evidence.

## Verification

- Public repository: https://github.com/mirkobozzetto/arsenal
- Release: https://github.com/mirkobozzetto/arsenal/releases/tag/v2.1.0
- Codex plugin metadata and installation instructions are included in the repository.