### PR TITLE
Add orca-replay to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [gh-address-comments/](./gh-address-comments/) - Address review or issue comments on the open GitHub PR for the current branch using `gh`.
 - [gh-fix-ci/](./gh-fix-ci/) - Inspect failing GitHub Actions checks, summarize failures, and propose fixes.
 - [mcp-builder/](./mcp-builder/) - Build and evaluate MCP servers with best practices and an evaluation harness.
+- [orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) - Answer why an earlier agent run did something, from its recording rather than from memory; replay it offline or fork it onto another model.
 - [pr-review-ci-fix/](./pr-review-ci-fix/) - Automated GitHub/GitLab PR review plus CI auto-fix loop via the Composio CLI.
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.


### PR DESCRIPTION
Adds `orca-replay` to **Skills → Development & Code Tools**, placed alphabetically.

The skill is about what happened, not what to do next: it tells the agent to answer "why did the earlier run delete that file" from the **recording** — what was actually sent, run and changed — instead of reconstructing it from context, and to keep what the trace shows apart from what it is inferring.

`codebase-recon` in this section reads git history to understand a codebase; this reads the agent's own session the same way. Behind it, OrcaReplay records at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls sit on one timeline. That run then replays offline with the network off, reproducing it byte-for-byte, or forks from a checkpoint onto a different model.

Codex is supported: `orca record codex` works with an API key, and a ChatGPT-subscription login is handled with `--tls-intercept` since that talks only to its own backend.

Apache-2.0. The same SKILL.md was reviewed and merged into `sickn33/agentic-awesome-skills` and is published on ClawHub after its security scan. It needs the `orcareplay` npm package with its MCP server registered — declared in the skill's frontmatter. Repository is nine days old at 150 stars.
