### PR TITLE
Add ironloop — verification-first 5-layer engineering harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Codex skills are modular instruction bundles that tell Codex how to execute a ta
 - [sentry-triage/](./sentry-triage/) - Diagnose Sentry issues by mapping stack frames to local source — no copy-paste.
 - [webapp-testing/](./webapp-testing/) - Run targeted web app tests and summarize results.
 - [AuraKit](https://github.com/smorky850612/Aurakit) - All-in-one skill framework: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Install: `npx @smorky85/aurakit`
+- [ironloop](https://github.com/edouard-claude/ironloop) - Verification-first 5-layer engineering harness (spec→gen→test→sim→pentest). Wraps AI-generated code in an iron harness of tests, chaos simulation, and multi-model pentesting.
 - [Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills) - Governed Codex skill harness for staged, test-driven work: routes 340+ skills through requirement freeze, plan approval, execution, verification evidence, and cross-session memory.
 - [polywave](https://github.com/blackwell-systems/polywave-codex) - Parallel agent coordination with structural merge safety. Scout decomposes, Wave agents implement in isolated worktrees with disjoint file ownership. Same protocol on Claude Code and Codex.
 


### PR DESCRIPTION
## ironloop

Verification-first 5-layer development harness (spec→gen→test→sim→pentest) for AI-assisted coding. Works with Codex, Claude Code, Gemini CLI, Cursor.

**Repo:** https://github.com/edouard-claude/ironloop
**Install:** `npx skills add edouard-claude/ironloop`

5 layers: specification → generation + compiler loop → TDD → chaos simulation → multi-model pentest. Rust-native, Agent Skills spec compliant, LLM-agnostic.