### PR TITLE
Add 5 Taiwan daily-life skills from baodao-skill

### DIFF
--- a/cwa-weather/SKILL.md
+++ b/cwa-weather/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: cwa-weather
+description: 用中央氣象署（CWA）開放資料 API 查各縣市與鄉鎮的天氣預報（天氣現象、降雨機率、氣溫、舒適度）。天氣、天氣預報、氣溫、降雨機率、明天天氣、週末天氣、台北天氣、高雄天氣的問題適用。需要在 opendata.cwa.gov.tw 免費申請的 API 金鑰。颱風警報、豪雨特報、地震速報不適用（請看中央氣象署官網）;沒有金鑰時改用 taiwan-weather（Open-Meteo 免金鑰）。
+license: MIT
+metadata:
+  category: weather
+  locale: zh-TW
+---
+
+# cwa-weather
+
+用中央氣象署（CWA）開放資料平臺（opendata.cwa.gov.tw）查正式天氣預報。**這是官方資料**，正式預報優先用這裡;免金鑰備援是 `taiwan-weather`（Open-Meteo）。
+
+**需要 API 金鑰（免費、即時發給）:** 到 https://opendata.cwa.gov.tw 註冊會員，登入後在「會員專區」即可看到授權碼。沒有金鑰時呼叫會回 `401 Forbidden: Authorization key is not correct.`（2026-09-09 實測）。使用者沒有金鑰時，請改用 `taiwan-weather` 或引導使用者申請，不要編造預報內容。
+
+颱風動態、豪雨特報、各種警報、地震速報**不在本技能範圍**，一律以中央氣象署 https://www.cwa.gov.tw 為準。
+
+## 基本流程
+
+1. 請使用者提供 CWA 授權碼（或確認環境中已有）
+2. 依需求選資料集:縣市 36 小時預報，或鄉鎮逐區預報
+3. 帶 `Authorization` 參數呼叫，解析 JSON
+
+### 1. 縣市 36 小時預報（F-C0032-001）
+
+```bash
+curl -sm 30 'https://opendata.cwa.gov.tw/api/v1/rest/datastore/F-C0032-001?Authorization=<授權碼>&locationName=臺北市' -o /tmp/cwa.json
+```
+
+- 一次最多查多個縣市:`locationName=臺北市,新北市`;不帶則回全部縣市。
+- 回傳 JSON（預設;`&format=XML` 可換 XML）。結構:`records.location[]`，每縣市含 `locationName` 與 `weatherElement[]`:`Wx`（天氣現象）、`PoP`（降雨機率 %）、`MinT`（最低溫）、`CI`（舒適度）、`MaxT`（最高溫），各元素 `time[]` 內有 `startTime`/`endTime`/`parameter.parameterName`。
+
+### 2. 鄉鎮預報（F-D0047 系列）
+
+每個縣市有各自的 dataset id（`F-D0047-xxx`，一週逐 12 小時或 3 小時鄉鎮預報）。到 https://opendata.cwa.gov.tw 資料目錄搜尋「鄉鎮天氣預報」確認目標縣市的 id，呼叫方式相同:
+
+```bash
+curl -sm 30 'https://opendata.cwa.gov.tw/api/v1/rest/datastore/<F-D0047-xxx>?Authorization=<授權碼>&locationName=<鄉鎮市區名>'
+```
+
+### 實測記錄
+
+2026-09-09 實測:未帶金鑰與帶無效金鑰呼叫 `F-C0032-001` 皆回 `401 Forbidden: Authorization key is not correct.`。**本技能未持有效金鑰做端到端實測**;端點、參數與回傳結構依 CWA 開放資料平臺官方文件（https://opendata.cwa.gov.tw 的 API 文件與資料集說明頁）。首次實際使用時，若回傳結構與上述不符，以實際回傳為準並回報差異。
+
+## 錯誤與失敗時的處理
+
+- **401 / Authorization key is not correct**:沒有金鑰或金鑰錯誤。請使用者到 opendata.cwa.gov.tw 會員專區確認授權碼;使用者不想申請就改用 `taiwan-weather`。
+- **連線逾時 / 5xx**:`curl` 一律加 `-m 30`，重試 1~2 次;仍失敗就告知 CWA 開放資料平臺可能暫時異常，正式預報請看 https://www.cwa.gov.tw。不要編造天氣。
+- **回傳不是 JSON 或 `success` 為 false**:視為失敗，如實回報回傳訊息，不要用舊資料冒充。
+- **颱風、警報、地震相關問題**:本技能不提供。直接請使用者看中央氣象署官網或 App。
+- **金鑰是秘密**:不要把授權碼寫進回覆、文件或提交紀錄;範例一律用 `<授權碼>` 占位。
+
+
+## 警特報、颱風與地震
+
+本技能只涵蓋一般天氣預報。颱風動態、豪雨特報、各種警報與地震速報:
+
+- **免金鑰**:用 taiwan-weather 技能裡的 NCDR CAP 公開 feed（國家災害防救科技中心彙整的官方警報,含颱風、地震、海嘯、淹水等類型,2026-09-09 實測可用）。
+- CWA 官網的警報頁有 Bot 防護（2026-09-09 實測從一般網路連線回 403）,不適合程式查詢。
+- CWA 開放資料平台另有警特報相關資料集（同樣用本技能的授權碼呼叫）,但截至 2026-09-09 未逐一實測;要使用時請先到 https://opendata.cwa.gov.tw 資料目錄確認資料集 id 再實測,不要直接引用未驗證的 id。
+
+正式警報內容一律以中央氣象署公告為準。
+
+## Open-Meteo（taiwan-weather）vs 本技能怎麼選
+
+有授權碼時正式預報優先用本技能（官方資料、鄉鎮級）;手邊沒金鑰或只要快速概況時用 taiwan-weather（Open-Meteo,國際模式,可能與官方預報有落差）。兩者的警報查詢都走 taiwan-weather 的 NCDR CAP 段。
+
+## English summary
+
+Queries official weather forecasts (36-hour per-county via F-C0032-001， township forecasts via the F-D0047 series) from Taiwan's Central Weather Administration open-data platform. Requires a free, instantly issued API key from opendata.cwa.gov.tw - keyless and bad-key calls return 401 (verified 2026-09-09; no end-to-end test with a real key yet, so the response layout follows the official docs). For typhoons, heavy-rain advisories, warnings, and earthquake reports, use the keyless NCDR CAP feeds documented in taiwan-weather (the CWA website is bot-protected; verified 403 on 2026-09-09) - official announcements remain at https://www.cwa.gov.tw. Without a key, fall back to the keyless taiwan-weather (Open-Meteo) skill. Never echo the user's key into replies or commits.

--- a/invoice-winning-numbers/SKILL.md
+++ b/invoice-winning-numbers/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: invoice-winning-numbers
+description: 從財政部電子發票整合服務平台查統一發票最新中獎號碼並對獎,支援批次對獎、雲端發票專屬獎(PDF 清單)、歷史期別查詢與每期自動對獎流程。發票對獎、統一發票、中獎號碼、特別獎、特獎、頭獎、增開六獎、雲端發票專屬獎、兌獎期限的問題適用。免 API 金鑰、免登入。發票以外的稅務申報、記帳問題不適用。
+license: MIT
+metadata:
+  category: finance
+  locale: zh-TW
+---
+
+# invoice-winning-numbers
+
+從財政部電子發票整合服務平台(https://invoice.etax.nat.gov.tw)的公開頁面取得統一發票中獎號碼,並用手上的發票號碼對獎。不需要 API 金鑰或登入,`curl` 即可。支援:最新期對獎、批次對獎、雲端發票專屬獎(PDF 清單)、歷史期別、每期自動對獎流程。
+
+## 基本流程
+
+1. 下載最新中獎號碼頁
+2. 移除 HTML 標籤後解析期別與各獎號碼
+3. 用使用者的 8 位發票號碼對獎
+
+### 1. 下載頁面
+
+```bash
+curl -sm 30 https://invoice.etax.nat.gov.tw/lastNumber.html -o /tmp/lastNumber.html
+```
+
+2026-09-09 實測:HTTP 200、約 20KB、不需特殊 User-Agent。頁面含最新一期的「中獎號碼單」(當日為 115年05-06月,特別獎 19531471、特獎 85941329、頭獎 07225810 / 20231230 / 83518781,無增開六獎),以及特別獎、特獎中獎清冊連結。雲端發票專屬獎在 `cloudNowNumber.html`(見下文專節)。
+
+**領獎期間陷阱:** 頁面上的「領獎期間」文字只屬於它所在區塊的期別。2026-09-09 實測時,最新號碼單已是 115年05-06月,頁面殘留的「領獎期間自115年06月06日起至115年09月07日止」卻是上一期(115年03-04月)的,直接配對會讓使用者錯過領獎。領獎期間只能引用與期別標籤同一區塊的文字;取不到對應區塊時,依規則說明「開獎日(單月 25 日)次月 6 日起算 3 個月」(例:115年05-06月期,115年7月25日開獎,領獎期間為115年8月6日至11月5日),並請使用者到 https://invoice.etax.nat.gov.tw 確認實際期限。
+
+### 2. 解析
+
+**務必先把 HTML 標籤「整個刪掉」(取代成空字串)再取數字。** 號碼會被標籤切開(例如頭獎 07225810 在原始碼中被拆成 `072</span><span ...>25810` 兩段)。如果把標籤取代成空白,數字會斷成 3 碼碎片(`072`、`258`、`10`),對獎會全錯;直接對原始 HTML 下正則也會漏。
+
+```bash
+python3 - <<'PY'
+import re
+h = open('/tmp/lastNumber.html', encoding='utf-8').read()
+text = re.sub(r'<[^>]+>', '', h)   # 標籤整個刪除,不要取代成空白
+text = re.sub(r'\s+', ' ', text)
+m = re.search(r'(1\d\d年\d\d-\d\d月)中獎號碼單', text)
+print('期別:', m.group(1) if m else '找不到')
+if m:
+    seg = text[m.end():m.end()+1200]
+    for prize in ['特別獎', '特獎']:
+        i = seg.find(prize)
+        n = re.search(r'\d{8}', seg[i:i+100]) if i >= 0 else None
+        print(prize, n.group(0) if n else '找不到')
+    i = seg.find('頭獎')
+    if i >= 0:
+        j = seg.find('同期', i)          # 頭獎可能多組,取到說明文字前為止
+        print('頭獎', re.findall(r'\d{8}', seg[i:j if j > i else i+200]))
+    i = seg.find('增開六獎')
+    if i >= 0:                            # 不是每期都有
+        print('增開六獎', re.findall(r'(?<!\d)\d{3}(?!\d)', seg[i:i+100]))
+PY
+```
+
+2026-09-09 實測(115年05-06月期):特別獎 `19531471`、特獎 `85941329`、頭獎 `07225810` `20231230` `83518781` 三組皆完整取出,無增開六獎。
+
+獎項結構(2026-09-09 實測頁面記載):
+
+| 獎項 | 條件 | 獎金 |
+| --- | --- | --- |
+| 特別獎 | 8 碼全同 | 1,000 萬元 |
+| 特獎 | 8 碼全同 | 200 萬元 |
+| 頭獎 | 8 碼全同(可能有多組) | 20 萬元 |
+| 二獎 | 末 7 碼與任一頭獎末 7 碼相同 | 4 萬元 |
+| 三獎 | 末 6 碼相同 | 1 萬元 |
+| 四獎 | 末 5 碼相同 | 4 千元 |
+| 五獎 | 末 4 碼相同 | 1 千元 |
+| 六獎 | 末 3 碼相同 | 2 百元 |
+
+### 3. 對獎(含批次)
+
+拿到使用者的發票號碼後(一張或多張):
+
+1. 先比對特別獎、特獎的完整 8 碼。
+2. 再比對每一組頭獎:8 碼全同 → 頭獎;否則取使用者號碼末 7 碼與頭獎末 7 碼比,中則二獎;依此類推到末 3 碼(六獎)。
+3. 若有「增開六獎」的 3 碼,另比末 3 碼。
+4. 一張發票同時對中多個獎項時,以兌領一個獎項為限(頁面領獎說明記載),回報時以最高獎金者為主。
+
+批次對獎(多張發票一次對完)範例:
+
+```bash
+python3 - <<'PY'
+import re
+h = open('/tmp/lastNumber.html', encoding='utf-8').read()
+text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', h))
+m = re.search(r'(1\d\d年\d\d-\d\d月)中獎號碼單', text)
+seg = text[m.end():m.end()+1200]
+sp = re.search(r'\d{8}', seg[seg.find('特別獎'):][:100]).group(0)
+st = re.search(r'\d{8}', seg[seg.find('特獎'):][:100]).group(0)
+i = seg.find('頭獎'); j = seg.find('同期', i)
+heads = re.findall(r'\d{8}', seg[i:j if j > i else i+200])
+i = seg.find('增開六獎')
+six = re.findall(r'(?<!\d)\d{3}(?!\d)', seg[i:i+100]) if i >= 0 else []
+
+mine = ['12345678', '87654321']   # 使用者的發票號碼,可放多張
+prizes = ['頭獎','二獎','三獎','四獎','五獎','六獎']
+for n in mine:
+    if n == sp:   print(n, '特別獎 1000萬'); continue
+    if n == st:   print(n, '特獎 200萬'); continue
+    hit = None
+    for k in range(8, 2, -1):
+        if any(n[-k:] == hd[-k:] for hd in heads):
+            hit = prizes[8-k]; break
+    if not hit and six and n[-3:] in six: hit = '增開六獎'
+    print(n, hit if hit else '沒中')
+PY
+```
+
+回報時附上:期別、中獎號碼、領獎期間(只引用與該期別同區塊的文字,否則依上述規則推算並加註需向官方確認)、出處 URL。民國年 = 西元年 - 1911(例:115年 = 2026年)。
+
+## 雲端發票專屬獎
+
+雲端發票專屬獎的中獎號碼**不在 HTML 頁面內**,而是每個獎別一份 PDF 清單(2026-09-09 實測)。流程:
+
+```bash
+# 1. 下載專屬獎頁面,取出所有 PDF 連結
+curl -sm 30 https://invoice.etax.nat.gov.tw/cloudNowNumber.html -o /tmp/cloud.html
+grep -oE 'pdf/[^"]+\.pdf' /tmp/cloud.html | sort -u
+
+# 2. 下載「已排序(sorted)」版本,用 pdftotext 取號碼
+curl -sm 30 'https://invoice.etax.nat.gov.tw/pdf/<檔名>.pdf' -o /tmp/prize.pdf
+pdftotext /tmp/prize.pdf /tmp/prize.txt
+```
+
+- PDF 連結形如 `pdf/<期別>_<時間戳>_sorted_AI_<X>.pdf`;**獎別不要靠檔名猜**,開啟後第一行有標題(2026-09-09 實測:`AI_B`=兩千元獎、`AI_C`=百萬元獎、`AI_D`=五百元獎、`AI_E`=八百元獎,但代碼可能變動)。
+- 號碼格式是「2 碼英文字軌 + 8 碼數字」(例 `AD00349792`)。專屬獎規則(頁面領獎注意事項記載):**字軌號碼完全相同才中獎**,沒有末幾碼的部分獎;且開獎前已列印紙本電子發票者喪失專屬獎資格。
+- 對獎時把使用者的 10 碼(字軌+數字)與每份清單全文比對;同時對中專屬獎與一般獎別時以領取 1 個獎金為限。
+- 歷年專屬獎:https://invoice.etax.nat.gov.tw/cloudListNumber.html 列出所有過往期別的 PDF 連結(2026-09-09 實測 HTTP 200、約 100KB)。
+
+## 歷史期別與每期自動對獎
+
+- **一般統一發票**:`lastNumber.html` 只有最新一期。歷史期別在財政部稅務入口網,URL 規則為 `https://www.etax.nat.gov.tw/etw-main/ETW183W2_<民國年3碼+起始月2碼>`(例:115年05-06月期 = `ETW183W2_11505`)。注意:該站是 JavaScript 渲染頁面,`curl` 抓不到號碼內容(2026-09-09 實測),只能給使用者連結手動確認;可程式化解析的歷史只有雲端發票專屬獎(`cloudListNumber.html`)。
+- **每期自動對獎流程(代理主動提醒)**:統一發票每兩個月一期,**單月 25 日開獎**。使用者若給過固定發票號碼(或載具末幾碼),代理可自行排定:開獎日當天下載最新 `lastNumber.html`(及 `cloudNowNumber.html` 的 PDF 清單),用上面的批次腳本對獎,中獎才回報,沒中簡短帶過。開獎日前頁面顯示的仍是上一期,屬正常現象,不要把上一期號碼當本期回報。
+
+## 錯誤與失敗時的處理
+
+- **連線逾時**:`curl` 一律加 `-m 30`。逾時或 5xx 時隔幾秒重試 1~2 次;仍失敗就告知「財政部電子發票整合服務平台可能暫時異常,請直接到 https://invoice.etax.nat.gov.tw 確認」,不要自己編號碼。
+- **頁面結構改變**:解析不到「中獎號碼單」或獎項標籤時,停止解析,告知頁面結構可能改版,請使用者到官方網站直接確認。不要用舊快取冒充最新資料。
+- **期別混淆**:頁面同時出現多個期別(號碼單與清冊連結)。永遠以「○○○年○○-○○月中獎號碼單」標籤正下方的表格為準,並把期別一起回報。
+- **領獎期間錯配**:頁面殘留的領獎期間常是上一期的。不要把與期別標籤不同區塊的領獎期間當成本期的;取不到時依「開獎日次月 6 日起 3 個月」推算並註明請向官方確認,不要把推算值說成官方公告。
+- **專屬獎 PDF 失效**:PDF 檔名含期別與時間戳,每期都換。永遠從 `cloudNowNumber.html`(或歷年頁 `cloudListNumber.html`)即時取連結,不要 hardcode 舊檔名。
+- **開獎時間**:統一發票每兩個月一期,單月 25 日開獎。開獎日前頁面顯示的是上一期,這是正常現象。
+
+## English summary
+
+Fetches Taiwan uniform-invoice winning numbers from the Ministry of Finance's public e-invoice pages (no API key, no login; `curl` is enough) and matches invoice numbers against them - single or batch. Always strip HTML tags before extracting numbers (they are split across tags), report the period label and claim window with the numbers, and never invent numbers when the fetch or parse fails. Cloud-invoice exclusive prizes live in per-prize PDF lists linked from cloudNowNumber.html (extract with pdftotext; identify the prize by the PDF's header line, not the filename; full serial = 2 letters + 8 digits, exact match only; historical periods at cloudListNumber.html). Regular-invoice history is only on the JS-rendered tax portal (ETW183W2_<period>) - hand the user the link rather than scraping. Draws happen on the 25th of every odd month; agents can proactively re-check a user's saved numbers on draw day and report only wins.

--- a/taiwan-garbage/SKILL.md
+++ b/taiwan-garbage/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: taiwan-garbage
+description: 查台北市與新北市的垃圾車清運點、路線與停靠時間。垃圾車、倒垃圾、垃圾時間、清運點、資源回收車、幾點來、今天有沒有收垃圾的問題適用。免登入,台北用臺北市資料大平臺 CSV,新北用新北市資料開放平臺 JSON。其他縣市尚未支援;是計畫停靠時間,不是即時 GPS。
+license: MIT
+metadata:
+  category: city
+  locale: zh-TW
+---
+
+# taiwan-garbage
+
+查垃圾車清運點與停靠時間。台北市用 data.taipei 的 CSV,新北市用 data.ntpc.gov.tw 的 JSON API,都免登入、免 API 金鑰。兩市資料格式完全不同,見各自章節。
+
+## 基本流程
+
+1. 依城市下載對應資料
+2. 依行政區、里別、地址或經緯度篩選
+3. 用現在時間(Asia/Taipei)找出「下一班車」;新北資料可再依星期幾判斷「今天有沒有收」
+
+## 台北市(data.taipei CSV)
+
+### 1. 下載
+
+```bash
+curl -sLm 30 'https://data.taipei/api/dataset/6bb3304b-4f46-4bb0-8cd1-60c66dcd1cae/resource/a6e90031-7ec4-4089-afb5-361a4efe7202/download' -o /tmp/tpe_garbage.csv
+```
+
+2026-09-09 實測:HTTP 200、`text/csv`、約 550KB、UTF-8(有 BOM)。這是計畫停靠時間的靜態路線資料,不是即時 GPS;每次使用重新下載即可。
+
+**下載連結的 resource id 可能更換。** 若 404,打開資料集頁 https://data.taipei/dataset/detail?id=6bb3304b-4f46-4bb0-8cd1-60c66dcd1cae ,在頁面原始碼找 `/api/dataset/<資料集id>/resource/<新的resource id>/download` 形式的連結替換。
+
+### 2. 欄位
+
+```
+行政區,里別,分隊,局編,車號,路線,車次,抵達時間,離開時間,地點,經度,緯度
+```
+
+- `抵達時間` / `離開時間` 是 `HHMM` 字串(例如 `1630` = 16:30)。
+- 一個里可能有多個清運點、多個車次。
+- `經度` / `緯度` 可拿來算離指定座標最近的清運點。
+
+### 3. 查詢範例
+
+```bash
+# 去掉 BOM 後,查某個里的所有清運點
+sed '1s/^\xef\xbb\xbf//' /tmp/tpe_garbage.csv > /tmp/g.csv
+awk -F',' '$2=="天壽里" {print $10, "抵達", $8, "離開", $9, "(" $6 " " $7 ")"}' /tmp/g.csv
+
+# 找出大安區今天 18:00 之後還會到的點(時間是 HHMM 字串,可直接比字串)
+awk -F',' '$1=="大安區" && $8>="1800" {print $2, $10, "抵達", $8}' /tmp/g.csv | sort -t' ' -k3
+
+# 找離指定座標最近的 5 個清運點(以緯度 25.033、經度 121.565 為例)
+awk -F',' -v la=25.033 -v lo=121.565 'NR>1 {
+  d=($12-la)*($12-la)+($11-lo)*($11-lo); printf "%.8f %s %s %s 抵達%s\n", d, $1, $2, $10, $8
+}' /tmp/g.csv | sort -n | head -5
+```
+
+「下一班車」的做法:把現在時間(Asia/Taipei)轉成 `HHMM`,篩出同里且 `抵達時間` 大於現在的列,取最早的一班,回報地點、抵達時間、路線與車次。
+
+## 新北市(data.ntpc.gov.tw JSON)
+
+### 1. 下載(分頁)
+
+```bash
+curl -sm 30 'https://data.ntpc.gov.tw/api/datasets/EDC3AD26-8AE7-4916-A00B-BC6048D19BF8/json?page=0&size=10000' -o /tmp/ntpc_g0.json
+curl -sm 30 'https://data.ntpc.gov.tw/api/datasets/EDC3AD26-8AE7-4916-A00B-BC6048D19BF8/json?page=1&size=10000' -o /tmp/ntpc_g1.json
+curl -sm 30 'https://data.ntpc.gov.tw/api/datasets/EDC3AD26-8AE7-4916-A00B-BC6048D19BF8/json?page=2&size=10000' -o /tmp/ntpc_g2.json
+jq -s 'add' /tmp/ntpc_g0.json /tmp/ntpc_g1.json /tmp/ntpc_g2.json > /tmp/ntpc_g.json
+```
+
+2026-09-09 實測:HTTP 200;全量 26,655 列(page 0/1 各 10,000 列、page 2 有 6,655 列),每頁約 5-7MB。**size 上限 10,000,不給 page 參數只會拿到第一頁**,務必分頁抓到空頁為止。資料量大,短時間內重複查詢請用同一份快取。
+
+### 2. 欄位
+
+| 欄位 | 意義 |
+| --- | --- |
+| `city` | 行政區(板橋區、新店區…) |
+| `village` | 里別 |
+| `lineid` / `linename` | 路線編號 / 路線名 |
+| `rank` | 停靠順序 |
+| `name` | 清運點地點描述 |
+| `longitude` / `latitude` | 座標(字串) |
+| `time` | 停靠時間 `HH:MM`(字串) |
+| `garbagemonday`…`garbagesunday` | 該日是否收一般垃圾(`Y` = 有,空字串 = 無) |
+| `recyclingmonday`…`recyclingsunday` | 該日是否收資源回收(`Y` = 有) |
+| `memo` | 備註 |
+
+### 3. 查詢範例
+
+```bash
+# 板橋區今天晚上 18:00 後還會到的點
+jq -r '.[] | select(.city=="板橋區" and .time>="18:00") | "\(.village) \(.name) \(.time) \(.linename)"' /tmp/ntpc_g.json | sort -t' ' -k3 | head
+
+# 星期三有收垃圾的點(garbagewednesday == "Y")
+jq -r '.[] | select(.city=="新店區" and .garbagewednesday=="Y") | "\(.village) \(.name) \(.time)"' /tmp/ntpc_g.json | head
+
+# 離指定座標最近且今天(以星期五為例)有收的 5 個點
+jq -r --argjson la 25.012 --argjson lo 121.465 '
+  [.[] | select(.garbagefriday=="Y")
+   | . + {d: ((.latitude|tonumber)-$la)*((.latitude|tonumber)-$la) + ((.longitude|tonumber)-$lo)*((.longitude|tonumber)-$lo)}]
+  | sort_by(.d) | .[0:5][] | "\(.city)\(.village) \(.name) \(.time)"' /tmp/ntpc_g.json
+```
+
+「今天有沒有收」的做法:把今天星期幾對到 `garbage<english weekday>` 欄位(`monday`~`sunday` 全小寫),`Y` 就是有收;資源回收看 `recycling<weekday>`。注意例假日、國定假日與颱風天的停收異動以新北市政府環境保護局公告為準。
+
+## 錯誤與失敗時的處理
+
+- **HTTP 404(台北)**:resource id 已更換。依上面的步驟回資料集頁重新解析下載連結;解析不到就如實告知資料集頁結構改變,請使用者到 data.taipei 手動下載。
+- **下載到 HTML 而不是 CSV/JSON**(例如錯誤頁):視為失敗,重試 1~2 次,仍失敗就告知來源異常。
+- **BOM / 編碼(台北)**:檔案開頭有 UTF-8 BOM,解析前先去掉(上面的 `sed` 範例),否則第一欄欄名比對會失敗。
+- **新北只抓到 10,000 列**:忘了分頁。`size` 上限 10,000,全量約 2.7 萬列(2026-09-09 實測),要 `page=0,1,2…` 抓到空頁為止。
+- **查不到某個里**:確認里名寫法(「里」結尾、繁體),再用行政區擴大範圍列出可選的里,讓使用者挑;不要猜最近似的一筆直接回報。
+- **其他縣市**:此技能只涵蓋台北市與新北市。桃園、台中、台南、高雄等縣市請回報尚未支援,或查閱該縣市開放資料平台。
+- **計畫時間 vs 實際**:兩市都是計畫停靠時間,實際抵達受路況影響;停收日、國定假日與颱風天異動以各市環保局公告為準。
+
+## English summary
+
+Looks up garbage-truck collection stops and scheduled times for Taipei City and New Taipei City (no login, no API key). Taipei uses the data.taipei CSV (~550KB, `HHMM` times, strip the UTF-8 BOM; the download resource id can rotate - re-resolve from the dataset page on 404). New Taipei uses the data.ntpc.gov.tw JSON API, which paginates at 10,000 rows per page - fetch pages 0-2 for the full ~26.7k rows (verified 2026-09-09), with per-weekday `garbage<weekday>`/`recycling<weekday>` flags so "is there collection today" is answerable. Both sources carry lat/lon for nearest-stop queries. Times are planned stops, not live GPS; holiday and typhoon-day changes follow each city's DEP announcements.

--- a/taiwan-weather/SKILL.md
+++ b/taiwan-weather/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: taiwan-weather
+description: 用 Open-Meteo（免 API 金鑰）查台灣 22 縣市現在天氣與未來數日預報,並用 NCDR CAP 公開 feed（免金鑰）查颱風、地震、海嘯、淹水等災害警報。天氣、氣溫、下雨、降雨機率、明天天氣、週末天氣、颱風警報、地震速報、豪雨特報的問題適用,是沒有金鑰時的快速備援。有 CWA 授權碼時正式預報請用 cwa-weather。
+license: MIT
+metadata:
+  category: weather
+  locale: zh-TW
+---
+
+# taiwan-weather
+
+用 Open-Meteo 的免費 API 查台灣各地天氣。免 API 金鑰、免登入，`curl` 即可。
+
+**定位:免金鑰的立即備援。** 有 CWA 授權碼時，正式預報請優先用 `cwa-weather` 技能（官方資料）;本技能適合手邊沒有金鑰、只要快速概況時使用。
+
+**資料來源是 Open-Meteo 的國際氣象模式，不是中央氣象署（CWA）。** 颱風動態、豪雨特報、各種警報與正式預報，請一律以中央氣象署 https://www.cwa.gov.tw 為準。
+
+## 基本流程
+
+1. 決定地點的經緯度
+2. 呼叫 forecast API
+3. 解讀天氣代碼與數值
+
+### 1. 全台 22 縣市座標
+
+2026-09-09 以 Open-Meteo 地理編碼 API 逐一確認（注意:該 API **只認英文/拼音地名**，中文地名查不到;下表座標是用英文名稱查得）:
+
+| 縣市 | 緯度 | 經度 |
+| --- | --- | --- |
+| 台北市 | 25.053 | 121.526 |
+| 新北市（板橋） | 25.014 | 121.467 |
+| 桃園市 | 24.994 | 121.297 |
+| 新竹市 | 24.804 | 120.969 |
+| 新竹縣（竹北） | 24.838 | 121.008 |
+| 苗栗縣（苗栗市） | 24.564 | 120.824 |
+| 台中市 | 24.147 | 120.684 |
+| 彰化縣（彰化市） | 24.073 | 120.563 |
+| 南投縣（南投市） | 23.916 | 120.664 |
+| 雲林縣（斗六） | 23.709 | 120.543 |
+| 嘉義市 | 23.479 | 120.449 |
+| 嘉義縣（太保） | 23.459 | 120.332 |
+| 台南市 | 22.991 | 120.213 |
+| 高雄市 | 22.616 | 120.313 |
+| 屏東縣（屏東市） | 22.671 | 120.488 |
+| 宜蘭縣（宜蘭市） | 24.757 | 121.753 |
+| 花蓮縣（花蓮市） | 23.977 | 121.604 |
+| 台東縣（台東市） | 22.760 | 121.145 |
+| 澎湖縣（馬公） | 23.565 | 119.586 |
+| 金門縣 | 24.446 | 118.376 |
+| 連江縣（南竿） | 26.150 | 119.933 |
+| 基隆市 | 25.131 | 121.741 |
+| 墾丁（以恆春計） | 22.004 | 120.744 |
+| 埔里 | 23.966 | 120.970 |
+
+表裡沒有的地點，用免金鑰的地理編碼 API 查，**`name` 請用英文或拼音**（例:`Hengchun`、`Lugang`）:
+
+```bash
+curl -sm 30 'https://geocoding-api.open-meteo.com/v1/search?name=<英文地名>&count=5&country_code=TW'
+```
+
+2026-09-09 實測:中文地名（「台北市」「嘉義」「墾丁」等）在此 API 一律查無結果;英文地名也要注意同名地點（`Nantou` 會先命中中國廣東，`Kenting` 不在庫），務必確認回傳的 `country_code` 是 `TW`、`admin1` 合理再使用。查不到或對不上時，不要猜座標，改用 cwa-weather（需金鑰）或請使用者確認中央氣象署預報。
+
+### 2. 查詢
+
+```bash
+# 現在天氣(以台北市為例)
+curl -sm 30 'https://api.open-meteo.com/v1/forecast?latitude=25.053&longitude=121.526&current=temperature_2m,relative_humidity_2m,precipitation,weather_code,wind_speed_10m&timezone=Asia%2FTaipei'
+
+# 未來 3 天預報
+curl -sm 30 'https://api.open-meteo.com/v1/forecast?latitude=25.053&longitude=121.526&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&forecast_days=3&timezone=Asia%2FTaipei'
+```
+
+2026-09-09 實測:HTTP 200,`current` 回傳溫度、濕度、降水量、天氣代碼，時間為 Asia/Taipei 當地時間。回報時附上回傳的 `time` 欄位。
+
+### 3. 天氣代碼（WMO）對照
+
+| 代碼 | 意義 |
+| --- | --- |
+| 0 | 晴 |
+| 1 / 2 / 3 | 大致晴 / 局部多雲 / 多雲 |
+| 45 / 48 | 霧 / 凍霧 |
+| 51 / 53 / 55 | 毛毛雨（小/中/大） |
+| 61 / 63 / 65 | 雨（小/中/大） |
+| 66 / 67 | 凍雨 |
+| 71 / 73 / 75 / 77 | 雪 |
+| 80 / 81 / 82 | 陣雨 |
+| 85 / 86 | 陣雪 |
+| 95 | 雷雨 |
+| 96 / 99 | 雷雨伴冰雹 |
+
+## 錯誤與失敗時的處理
+
+- **連線逾時 / 5xx**:`curl` 一律加 `-m 30`，重試 1~2 次;仍失敗就告知 Open-Meteo 暫時異常，正式預報請看中央氣象署。不要編造天氣。
+- **回傳不是 JSON 或缺 `current`/`daily`**:視為失敗，不要用舊資料冒充。
+- **座標不在台灣**:確認 `country_code=TW` 的地理編碼結果，回傳的 `name` 與使用者問的地點不符時，先回報找到的地名再給天氣。中文地名在地理編碼 API 查不到是已知限制，改用英文/拼音，仍查不到就照上一節指示降級，不要自行估座標。
+- **颱風、警報相關問題**:本技能不提供。直接請使用者看中央氣象署或下載中央氣象署 App。
+
+
+## 災害警報與速報（NCDR CAP,免金鑰）
+
+Open-Meteo 本身沒有警報資料。台灣的颱風、地震、海嘯等災害警報可以用**國家災害防救科技中心（NCDR）的 CAP 公開 feed** 查,官方來源、免金鑰、免登入:
+
+```bash
+curl -sm 30 'https://alerts.ncdr.nat.gov.tw/RssAtomFeed.ashx?AlertType=5' -o /tmp/typhoon.xml
+```
+
+URL 形式為 `https://alerts.ncdr.nat.gov.tw/RssAtomFeed.ashx?AlertType=<類型代碼>`。類型代碼（2026-09-09 逐一實測）:
+
+| 代碼 | 類型 |
+| --- | --- |
+| 5 | 颱風 |
+| 6 | 地震 |
+| 7 | 海嘯 |
+| 8 | 淹水 |
+| 9 | 土石流及大規模崩塌 |
+| 10 | 降雨 |
+| 11 | 河川高水位 |
+
+1~4 回「存取檔案有誤」（不存在或未開放）。feed 是 Atom + CAP 格式:每則 entry 有 `<title>`（類型）、`<updated>`、`<summary>`（警報全文）、`<cap:expires>` 等;無有效警報時 feed 仍在但筆數少,近期已解除的警報也會留著,**回報前先確認發布時間與 expires,過期的警報不要當現況**。
+
+```bash
+# 列出颱風 feed 裡每則警報的標題與更新時間
+python3 - <<'PY2'
+import re
+h = open('/tmp/typhoon.xml', encoding='utf-8').read()
+for e in re.findall(r'<entry>(.*?)</entry>', h, re.S):
+    t = re.search(r'<title>([^<]*)</title>', e)
+    u = re.search(r'<updated>([^<]*)</updated>', e)
+    x = re.search(r'<cap:expires>([^<]*)</cap:expires>', e)
+    print(t.group(1) if t else '?', '|', u.group(1) if u else '?', '| expires:', x.group(1) if x else '-')
+PY2
+```
+
+**速率限制:連續請求間隔至少 3 秒**,否則回 `429 限制存取間隔時間為3秒`（2026-09-09 實測）。一次查多種類型時逐個加 sleep。正式警報內容仍以中央氣象署公告為準;這個 feed 是 NCDR 彙整各機關（氣象署、水利署等）的 CAP 警報。
+
+## Open-Meteo（本技能）vs CWA（cwa-weather）怎麼選
+
+| | taiwan-weather（Open-Meteo） | cwa-weather（CWA 開放資料） |
+| --- | --- | --- |
+| 金鑰 | 不需要 | 需要（免費即時發給） |
+| 資料來源 | 國際氣象模式 | 中央氣象署官方預報 |
+| 適合 | 快速概況、手邊沒金鑰 | 正式預報、鄉鎮級細節 |
+| 警報 / 颱風 / 地震 | NCDR CAP feed（本文件上方） | NCDR CAP feed 同樣適用;CWA 官網有 Bot 防護（2026-09-09 實測 403）不適合程式查 |
+| 準確性判斷 | 國際模式,山區/局部天氣可能與官方有落差 | 台灣官方預報為準 |
+
+## English summary
+
+Current weather and forecasts for 22 Taiwan counties via the keyless Open-Meteo API (curl only) - the fallback when no CWA API key is at hand; for official forecasts prefer cwa-weather. Disaster alerts (typhoon, earthquake, tsunami, flood, debris flow, rainfall, high river levels) are available keyless via the NCDR CAP Atom feeds at alerts.ncdr.nat.gov.tw - AlertType 5/6/7/8/9/10/11 respectively (types 1-4 do not exist); respect the 3-second rate limit (429 otherwise) and always check each entry's updated/expires before reporting an alert as current. The geocoding API only accepts English/pinyin names; verify country_code=TW before using coordinates.

--- a/youbike-realtime/SKILL.md
+++ b/youbike-realtime/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: youbike-realtime
+description: 查全台 14 個服務區(台北、新北、桃園、台中、台南、高雄等)YouBike 2.0 站點的即時可借車輛與可還空位,含電輔車篩選與最近站點查詢。YouBike、微笑單車、公共自行車、借車、還車、站點、哪裡有車的問題適用。免 API 金鑰、免登入。預約租車、費用計算不適用。
+license: MIT
+metadata:
+  category: transport
+  locale: zh-TW
+---
+
+# youbike-realtime
+
+查 YouBike 2.0 站點即時狀態:可借幾台、可還幾個空位。免 API 金鑰,`curl` + `jq` 即可。
+
+**兩層資料源**,優先用第 1 層:
+
+1. **官方統一 feed(全台 14 個服務區)**:youbike.com.tw 地圖實際使用的即時 JSON,一次取回全台約 9,500 站(2026-09-10 實測 9,521 站),含高雄、台南等市政府開放平台沒有的縣市,且每站都有電輔車明細。注意:這是**非公開文件化的 API**,欄位可能無預警調整,所以第 2 層保留作為備援。
+2. **各市政府開放資料 feed(台北、新北、台中、桃園)**:文件化的官方開放資料,統一 feed 失敗或欄位變更時改用。**高雄市政府的來源(openapi.kcg.gov.tw)2026-09-09 從台灣境外連線逾時、無法驗證,不要依賴**;高雄請用統一 feed。
+
+回報時一律附上資料更新時間,讓使用者知道資訊有多新。
+
+## 第 1 層:官方統一 feed(apis.youbike.com.tw)
+
+```bash
+curl -sm 60 https://apis.youbike.com.tw/json/station-yb2.json -o /tmp/youbike_all.json
+```
+
+2026-09-10 實測:HTTP 200、約 6.2MB、9,521 站、14 個服務區,回應內 `updated_at` 與查詢時刻差約 1 分鐘(近即時)。檔案大,短時間內重複查詢請用同一份快取(1~2 分鐘),不要連續請求。
+
+### 欄位
+
+| 欄位 | 意義 |
+| --- | --- |
+| `area_code` | 服務區代碼(字串,見下表;`"0A"` 等含英字,比對時當字串) |
+| `status` | `1` = 營運中,`2` = 暫停營運 |
+| `station_no` | 站點編號 |
+| `name_tw` / `name_en` | 站名(中 / 英;**沒有**市府 feed 的 `YouBike2.0_` 前綴) |
+| `district_tw` / `district_en` | 行政區 |
+| `address_tw` / `address_en` | 地址 |
+| `parking_spaces` | 總車位數(數字) |
+| `available_spaces` | 可借車輛數(數字) |
+| `available_spaces_detail` | 可借明細 `{yb1, yb2, eyb}`:YouBike 1.0 / 2.0 / 電輔車 |
+| `empty_spaces` | 可還空位數(數字) |
+| `lat` / `lng` | 站點座標(**字串**,算距離前要 `tonumber`) |
+| `updated_at` | 資料更新時間 `YYYY-MM-DD HH:MM:SS`(台灣時間 UTC+8) |
+
+### 服務區代碼(area_code,2026-09-10 實測)
+
+| 代碼 | 服務區 | 約略站數 | 代碼 | 服務區 | 約略站數 |
+| --- | --- | --- | --- | --- | --- |
+| `00` | 台北市 | 1,800 | `0B` | 新竹縣 | 210 |
+| `05` | 新北市 | 1,600 | `10` | 新竹科學園區 | 40 |
+| `07` | 桃園市 | 700 | `11` | 嘉義縣 | 190 |
+| `01` | 台中市 | 1,820 | `12` | 高雄市 | 1,500 |
+| `13` | 台南市 | 760 | `14` | 屏東縣 | 190 |
+| `08` | 嘉義市 | 220 | `15` | 台東縣 | 120 |
+| `09` | 新竹市 | 150 | `0A` | 苗栗縣 | 220 |
+
+### 查詢範例
+
+```bash
+# 高雄新興區有車可借的站(統一 feed 才有高雄)
+jq -r '.[] | select(.area_code=="12" and .district_tw=="新興區" and .status==1 and .available_spaces>0)
+  | "\(.name_tw) 可借\(.available_spaces) 可還\(.empty_spaces)"' /tmp/youbike_all.json
+
+# 台北找電輔車(市府 feed 沒有電輔車欄位,統一 feed 的 eyb 全台通用)
+jq -r '.[] | select(.area_code=="00" and .status==1 and .available_spaces_detail.eyb>0)
+  | "\(.name_tw) 電輔車\(.available_spaces_detail.eyb) 可還\(.empty_spaces)"' /tmp/youbike_all.json
+
+# 雙北邊界一次查(area_code 00+05),不用分兩支 feed 再合併
+jq -r '.[] | select((.area_code=="00" or .area_code=="05") and .status==1 and .available_spaces>0
+        and (.name_tw | gsub("臺";"台") | contains("台大")))
+  | "\(.name_tw) 可借\(.available_spaces)"' /tmp/youbike_all.json
+
+# 找離指定座標最近且有車的 5 站(以緯度 25.033、經度 121.565 為例;lat/lng 是字串)
+jq -r --argjson la 25.033 --argjson lo 121.565 '
+  [.[] | select(.status==1 and .available_spaces>0)
+   | . + {d: (((.lat|tonumber)-$la)*((.lat|tonumber)-$la) + ((.lng|tonumber)-$lo)*((.lng|tonumber)-$lo))}]
+  | sort_by(.d) | .[0:5][]
+  | "\(.name_tw) 可借\(.available_spaces) 可還\(.empty_spaces) \(.address_tw)"' /tmp/youbike_all.json
+```
+
+## 站名「台 / 臺」正規化(重要)
+
+站名混用「台」與「臺」:台北市府 feed 有 147 站用「臺」(2026-09-10 實測),新北兩者混用(「臺」27 站、「台」18 站),統一 feed 全台共 385 站名含「臺」。使用者打「台大」時,名叫「臺大」的站會全部漏掉。**搜尋站名前先把站名與關鍵字都正規化**:
+
+```bash
+# haystack 與 needle 都 gsub("臺";"台") 再比對
+jq -r --arg q '台大' '.[] | select(.name_tw | gsub("臺";"台") | contains($q | gsub("臺";"台"))) | .name_tw' /tmp/youbike_all.json
+```
+
+## 第 2 層:各市政府開放資料 feed(備援)
+
+統一 feed 連不上或欄位變更時改用。**四個城市的 feed 欄位命名分兩派**,不要混用 jq 篩選式:
+
+- 台北派:`available_rent_bikes` / `available_return_bikes` / `Quantity`(數字型)
+- 其他三市派:`sbi` / `bemp` / `tot`(字串型;新北另叫 `sbi_quantity` / `bemp` / `tot_quantity`)
+
+### 台北市
+
+```bash
+curl -sm 30 https://tcgbusfs.blob.core.windows.net/dotapp/youbike/v2/youbike_immediate.json -o /tmp/youbike.json
+```
+
+2026-09-10 實測:HTTP 200、約 940KB、約 1,800 站,約 1 分鐘更新一次。**台北 feed 沒有電輔車欄位**,要篩電輔車請用統一 feed 的 `available_spaces_detail.eyb`。
+
+| 欄位 | 意義 |
+| --- | --- |
+| `sno` | 站點編號 |
+| `sna` / `snaen` | 站名(中文 / 英文,帶 `YouBike2.0_` 前綴) |
+| `sarea` / `sareaen` | 行政區(中文 / 英文) |
+| `ar` / `aren` | 地址(中文 / 英文) |
+| `Quantity` | 總車位數 |
+| `available_rent_bikes` | 可借車輛數 |
+| `available_return_bikes` | 可還空位數 |
+| `act` | `1` = 營運中,其他 = 暫停營運 |
+| `latitude` / `longitude` | 站點座標 |
+| `srcUpdateTime` / `mday` | 資料更新時間 |
+
+```bash
+# 大安區還有車可借的站
+jq -r '.[] | select(.sarea=="大安區" and .act=="1" and .available_rent_bikes>0)
+  | "\(.sna) 可借\(.available_rent_bikes) 可還\(.available_return_bikes)"' /tmp/youbike.json
+```
+
+### 新北市(data.ntpc.gov.tw)
+
+```bash
+curl -sm 30 'https://data.ntpc.gov.tw/api/datasets/010E5B15-3823-4B20-B401-B1CF000550C5/json?page=0&size=5000' -o /tmp/youbike_ntpc.json
+```
+
+2026-09-10 實測:HTTP 200、`size=5000` 一次取回全部約 1,600 站(約 700KB)。分頁參數 `page`(0 起)與 `size`。
+
+欄位對照(新北 → 台北):
+
+| 新北欄位 | 台北欄位 | 意義 |
+| --- | --- | --- |
+| `sbi_quantity` | `available_rent_bikes` | 可借車輛數 |
+| `bemp` | `available_return_bikes` | 可還空位數 |
+| `tot_quantity` | `Quantity` | 總車位數 |
+| `lat` / `lng` | `latitude` / `longitude` | 站點座標 |
+| `act` | `act` | `1` = 營運中 |
+| `mday` | `mday` | 資料更新時間 |
+| `yb2_quantity` / `eyb_quantity` | (無) | 可借中一般車 / 電輔車數 |
+
+```bash
+# 板橋區還有電輔車可借的站
+jq -r '.[] | select(.sarea=="板橋區" and .act=="1" and (.eyb_quantity|tonumber)>0)
+  | "\(.sna) 電輔車\(.eyb_quantity) 一般\(.yb2_quantity) 可還\(.bemp)"' /tmp/youbike_ntpc.json
+```
+
+注意:新北 feed 的數量欄位是字串(`"9"` 不是 `9`),比較前用 `tonumber`。
+
+### 台中市(newdatacenter.taichung.gov.tw)
+
+```bash
+curl -sm 30 'https://newdatacenter.taichung.gov.tw/api/v1/no-auth/resource.download?rid=9468c0d0-e1ed-4ecc-a86f-ab5a9fd590ff' -o /tmp/youbike_tc.json
+```
+
+2026-09-10 實測:HTTP 200、約 750KB、約 1,820 站、一次全量下載不分頁。
+
+### 桃園市(opendata.tycg.gov.tw)
+
+```bash
+curl -sm 30 'https://opendata.tycg.gov.tw/api/v1/dataset.api_access?rid=08274d61-edbe-419d-8fcc-7a643831283d&format=json&limit=2000' -o /tmp/youbike_ty.json
+```
+
+2026-09-10 實測:HTTP 200;**不帶 `limit` 只回 20 站**,帶 `limit=2000` 取回全部約 700 站。**注意:若回傳筆數正好等於 `limit`,代表可能被截斷,把 `limit` 加大再查一次**。
+
+### 台中 / 桃園的共同欄位
+
+兩市 feed 欄位命名相同(與新北不同):
+
+| 欄位 | 意義 |
+| --- | --- |
+| `scity` / `scityen` | 城市(中文 / 英文) |
+| `sna` / `snaen` | 站名(中文 / 英文) |
+| `sarea` / `sareaen` | 行政區 |
+| `ar` / `aren` | 地址 |
+| `sno` | 站點編號 |
+| `tot` | 總車位數(字串) |
+| `sbi` | 可借車輛數(字串) |
+| `bemp` | 可還空位數(字串) |
+| `lat` / `lng` | 站點座標(字串) |
+| `act` | `1` = 營運中 |
+| `mday` | 資料更新時間 `YYYYMMDDHHMMSS` |
+| `sbi_detail` | 可借明細:**台中是 `"14,1"`(一般,電輔),桃園是 JSON 字串 `{"yb2":"14","eyb":"1"}`**,兩市格式不同 |
+
+```bash
+# 台中西區有可借車的站
+jq -r '.[] | select(.sarea=="西區" and .act=="1" and (.sbi|tonumber)>0)
+  | "\(.sna) 可借\(.sbi) 可還\(.bemp)"' /tmp/youbike_tc.json
+
+# 桃園找有電輔車的站(sbi_detail 是 JSON 字串,要 fromjson)
+jq -r '.[] | select(.act=="1" and ((.sbi_detail|fromjson|.eyb|tonumber) // 0) > 0)
+  | "\(.sna) 電輔車\(.sbi_detail|fromjson|.eyb) 可還\(.bemp)"' /tmp/youbike_ty.json
+```
+
+### 雙北合併查詢(市府 feed 版)
+
+統一 feed 用 `area_code` 一次解決;若只能做市府 feed,分別下載後用 `jq -s add` 合併,但因兩市欄位不同,先各自正規化成共同欄位再合併:
+
+```bash
+jq -sr '
+  (.[0] | map({sna, rent: .available_rent_bikes, ret: .available_return_bikes, act, lat: .latitude, lng: .longitude})) +
+  (.[1] | map({sna, rent: (.sbi_quantity|tonumber), ret: (.bemp|tonumber), act, lat: (.lat|tonumber), lng: (.lng|tonumber)}))
+  | .[] | select(.act=="1" and .rent>0) | "\(.sna) 可借\(.rent) 可還\(.ret)"' /tmp/youbike.json /tmp/youbike_ntpc.json
+```
+
+## 更新時間欄位格式(各市不同,全部為台灣本地時間 UTC+8)
+
+| 來源 | 欄位 | 格式範例 |
+| --- | --- | --- |
+| 統一 feed | `updated_at` | `2026-09-10 03:26:31` |
+| 台北 | `mday` / `infoTime` / `srcUpdateTime` / `updateTime` | `2026-09-10 03:25:04`(`infoDate` 另給日期) |
+| 新北 | `mday` | `20260910T032403` |
+| 台中 / 桃園 | `mday` | `20260910032603` |
+
+## 錯誤與失敗時的處理
+
+- **連線逾時 / 5xx**:`curl` 一律加 `-m 30`(統一 feed 用 `-m 60`),隔幾秒重試 1~2 次。
+- **統一 feed 失敗**:改用第 2 層市府 feed(雙北台中桃園);其他縣市則告知統一 feed 暫時異常,建議 YouBike 官方 App 或 https://www.youbike.com.tw 確認。
+- **市府 feed 失敗**:統一 feed 還正常時直接用統一 feed 頂替;兩層都失敗就告知公開資料源可能暫時異常。
+- **回傳空陣列或不是 JSON**:視為失敗,不要用舊資料冒充即時資料。
+- **`status` / `act` 不是營運中**:該站暫停營運,明確告知,不要只回報 0 台可借。
+- **數量為 0**:如實回報「目前無車可借 / 無位可還」,數量變動很快,建議出發前再查一次。
+- **桃園只查到 20 站**:忘了帶 `limit` 參數。預設只回 20 筆,全量約 700 站要 `limit=2000`(2026-09-10 實測);回傳筆數等於 `limit` 時要加大再查。
+- **`sbi_detail` 格式**:台中是逗號字串 `一般,電輔`,桃園是 JSON 字串。桃園要 `fromjson` 再取值;台中用 `split(",")`。
+- **站名搜不到**:先想「台 / 臺」問題,兩邊都 `gsub("臺";"台")` 再比對(見上文)。
+- **欄位混用**:四市欄位名分兩派(見開頭說明),統一 feed 又是第三套命名,把台北的 `available_rent_bikes` 套到台中資料會得到空結果,先確認資料源再選篩選式。
+- **高雄市**:用統一 feed(`area_code=="12"`)。高雄市政府 openapi.kcg.gov.tw 的 YouBike 端點 2026-09-09 從台灣境外連線逾時、無法驗證,不要依賴。
+
+## English summary
+
+Looks up real-time YouBike 2.0 availability nationwide in Taiwan (no API key; `curl` + `jq`). Two tiers: (1) the official unified feed at apis.youbike.com.tw/json/station-yb2.json - one call returns ~9,500 stations across 14 service areas including Kaohsiung and Tainan, with per-type bike detail (`available_spaces_detail` = {yb1, yb2, eyb}) and near-real-time `updated_at`; it is the feed the official map uses but is undocumented, so schema may change without notice. (2) Per-city open-data feeds (Taipei, New Taipei, Taichung, Taoyuan) as documented fallback - Taipei has no e-bike field, so use the unified feed for e-bike filtering. Field names split into families: Taipei numeric `available_rent_bikes`/`available_return_bikes`, other cities string-typed `sbi`/`bemp`/`tot` (New Taipei: `sbi_quantity`/`tot_quantity`), unified feed `available_spaces`/`empty_spaces`. Station names mix 台/臺 (147 Taipei stations use 臺) - normalize both sides with `gsub("臺";"台")` before matching. Taoyuan paginates at 20 rows unless you pass `limit=2000` (~700 stations); if the count equals the limit, raise it and requery. Update-time formats differ per city (`YYYY-MM-DD HH:MM:SS` Taipei/unified, `YYYYMMDDTHHMMSS` New Taipei, `YYYYMMDDHHMMSS` Taichung/Taoyuan), all Taiwan local time (UTC+8). Always quote the feed's update time, cache responses for 1-2 minutes instead of polling, and treat non-JSON or empty responses as failures - never pass stale data off as live.


### PR DESCRIPTION
Adds five agent skills from [tahodev/baodao-skill](https://github.com/tahodev/baodao-skill) (MIT), a collection for everyday life in Taiwan built only on official open data - no login, no scraping:

- **invoice-winning-numbers** - Taiwan uniform-invoice winning numbers: latest draw, batch checking, cloud-invoice exclusive prizes (official PDF list)
- **youbike-realtime** - YouBike 2.0 realtime station availability across 14 service areas, with e-bike filtering
- **taiwan-garbage** - Taipei and New Taipei garbage collection points and stop times, with weekday schedule logic
- **cwa-weather** - Central Weather Administration 36-hour and township forecasts (free, instantly issued API key)
- **taiwan-weather** - Keyless fallback: Open-Meteo weather plus NCDR CAP typhoon/earthquake/tsunami alerts

Each skill is a single `SKILL.md` with valid YAML frontmatter; the `description` states when the agent should trigger. All upstream endpoints are covered by a scheduled CI curl-check in the source repo. Install with `npx skills add tahodev/baodao-skill`. Skill content is in Traditional Chinese since the services are Taiwan-local.